### PR TITLE
fix(security): prevent ReDoS in stripSourceMapComment regex

### DIFF
--- a/src/rslib/plugins/dts-plugin.ts
+++ b/src/rslib/plugins/dts-plugin.ts
@@ -401,7 +401,7 @@ async function bundleDtsFiles(options: {
  * @public
  */
 export function stripSourceMapComment(content: string): string {
-	return content.replace(/\/\/# sourceMappingURL=.+\.d\.ts\.map\s*$/gm, "").trim();
+	return content.replace(/\/\/# sourceMappingURL=\S+\.d\.ts\.map\s*$/gm, "").trim();
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix polynomial ReDoS vulnerability (CWE-1333) in `stripSourceMapComment` by replacing `.+` with `\S+`
- The previous regex had ambiguity between `.+` (which can match whitespace) and `\s*$` (which also matches whitespace), causing polynomial backtracking on crafted inputs
- Source map URLs don't contain whitespace, so `\S+` is more semantically correct and eliminates the backtracking risk

Fixes #1 (code-scanning alert)

## Test plan

- [x] Existing tests for `stripSourceMapComment` pass
- [x] Typecheck passes