### PR TITLE
fix(dts): exclude API model from npm publish via files array

### DIFF
--- a/.changeset/calm-bird-719.md
+++ b/.changeset/calm-bird-719.md
@@ -1,0 +1,5 @@
+---
+"@savvy-web/rslib-builder": patch
+---
+
+Fix API model being incorrectly included in npm package. The file is now excluded via negation pattern (`!<filename>`) in the `files` array while still being emitted to dist for local tooling. Also renamed default filename to `<unscopedPackageName>.api.json` following API Extractor convention.

--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,5 @@ test.ts
 **/coverage-debug
 .claude/plugins-debug.log
 .playwright-mcp
-website/lib/packages/*/api.model.json
+website/lib/packages/*/*.api.json
 website/lib/packages/*/package.json

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@
  * - **Package.json Transformation**: Automatic path updates, PNPM catalog resolution
  * - **TypeScript Declaration Bundling**: Using tsgo and API Extractor
  * - **File Array Generation**: Automatic files array creation for package.json
- * - **API Model Generation**: Optional api.model.json for documentation tooling
+ * - **API Model Generation**: Optional `<packageName>.api.json` for documentation tooling
  *
  * @example
  * Basic usage in rslib.config.ts:

--- a/src/rslib/builders/node-library-builder.ts
+++ b/src/rslib/builders/node-library-builder.ts
@@ -159,13 +159,13 @@ export interface NodeLibraryBuilderOptions {
 	transform?: TransformPackageJsonFn;
 	/**
 	 * Options for API model generation.
-	 * When enabled, generates an api.model.json file in the dist directory.
+	 * When enabled, generates an `<unscopedPackageName>.api.json` file in the dist directory.
 	 * Only applies when target is "npm".
 	 *
 	 * @remarks
-	 * The generated api.model.json file contains the full API documentation
+	 * The generated API model file contains the full API documentation
 	 * in a machine-readable format for use by documentation generators.
-	 * A .npmignore file is also generated to exclude the API model from npm publish.
+	 * The file is emitted to dist but excluded from npm publish (added as negated pattern in `files` array).
 	 *
 	 * @example
 	 * ```typescript

--- a/src/rslib/plugins/dts-plugin.test.ts
+++ b/src/rslib/plugins/dts-plugin.test.ts
@@ -9,6 +9,7 @@ import {
 	findTsConfig,
 	generateTsgoArgs,
 	getTsgoBinPath,
+	getUnscopedPackageName,
 	stripSourceMapComment,
 } from "./dts-plugin.js";
 
@@ -75,6 +76,28 @@ ${SOURCE_MAP_PREFIX}index.d.ts.map`;
 export declare const foo: string;
 /** TSDoc comment */
 export declare const bar: number;`);
+		});
+	});
+
+	describe("getUnscopedPackageName", () => {
+		it("should extract name from scoped package", () => {
+			expect(getUnscopedPackageName("@scope/package-name")).toBe("package-name");
+		});
+
+		it("should return name unchanged for unscoped package", () => {
+			expect(getUnscopedPackageName("package-name")).toBe("package-name");
+		});
+
+		it("should handle scoped package with nested path", () => {
+			expect(getUnscopedPackageName("@my-org/my-package")).toBe("my-package");
+		});
+
+		it("should handle empty scope", () => {
+			expect(getUnscopedPackageName("@/package")).toBe("package");
+		});
+
+		it("should return original if no slash after @", () => {
+			expect(getUnscopedPackageName("@no-slash")).toBe("@no-slash");
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Fix API model being incorrectly published to npm (npm ignores `.npmignore` when `files` array is set)
- Remove `.npmignore` emission and instead exclude API model from `filesArray`
- Rename default filename from `api.model.json` to `<unscopedPackageName>.api.json` (follows API Extractor convention)
- Remove `npmIgnore` option from `ApiModelOptions` (no longer needed)
- Add `getUnscopedPackageName` helper function with tests

The API model is still emitted to dist for local tooling use via the `localPaths` option.

## Test plan

- [x] All 363 tests pass
- [x] Typecheck passes
- [x] Coverage thresholds met