### PR TITLE
feat: multi-entry API model generation and bundleless mode

### DIFF
--- a/.changeset/multi-entry-api-model.md
+++ b/.changeset/multi-entry-api-model.md
@@ -1,0 +1,45 @@
+---
+"@savvy-web/rslib-builder": minor
+---
+
+## Multi-entry API model generation
+
+Replace virtual barrel approach with per-entry API Extractor runs merged into a
+single `.api.json` with multiple `EntryPoint` members.
+
+### New behavior
+
+- API Extractor now runs for **every** entry point (not just the main `"."` export)
+- Per-entry models are merged into a single Package with multiple EntryPoint members
+- Sub-entry canonical references are scoped (e.g., `@scope/pkg/subpath!` instead
+  of `@scope/pkg!`)
+- Single-entry packages produce the same output as before (no merge needed)
+
+### API changes
+
+- Added `exportPaths: Record<string, string>` to `ExtractedEntries` interface,
+  mapping entry names back to original export keys (e.g., `"nested-one"` to
+  `"./nested/one"`) for lossless canonical reference scoping
+- Removed `extractEntriesFromPackageJson` convenience function from public API;
+  use `new EntryExtractor().extract(packageJson)` directly
+- Added `mergeApiModels()` internal function for combining per-entry API models
+
+### Bundleless mode
+
+- DtsPlugin now emits individual `.d.ts` files (preserving source structure)
+  when `bundle: false`, while still generating a merged API model across all
+  entry points
+- The `bundle` option on `DtsPluginOptions` controls whether declarations are
+  rolled up per entry (bundle) or emitted individually (bundleless)
+
+### Removed
+
+- Removed virtual barrel generator (`VirtualBarrelGenerator`, `BarrelEntry`,
+  `generateApiModelFromBarrel`, `BarrelApiModelResult`)
+- Removed `generateVirtualBarrel` option from `DtsPluginOptions`
+
+### Other changes
+
+- `reportUnsupportedHtmlElements` changed from `false` to `true` in TSDoc config
+- Extracted `resolveTsdocMetadataFilename` utility to deduplicate filename resolution
+- Replaced duplicated CI detection with `TsDocConfigBuilder.isCI()`

--- a/.claude/design/rslib-builder/api-extraction.md
+++ b/.claude/design/rslib-builder/api-extraction.md
@@ -3,8 +3,8 @@ status: current
 module: rslib-builder
 category: integration
 created: 2026-01-19
-updated: 2026-02-03
-last-synced: 2026-02-03
+updated: 2026-02-05
+last-synced: 2026-02-05
 completeness: 95
 related:
   - rslib-builder/architecture.md
@@ -66,7 +66,8 @@ bundled declarations and an API model file.
 1. **DtsPlugin** (`src/rslib/plugins/dts-plugin.ts`)
    - Purpose: Generates TypeScript declarations and optional API models
    - Status: Implemented
-   - Key functions: `bundleDtsFiles()`, `DtsPlugin()`
+   - Key functions: `bundleDtsFiles()`, `mergeApiModels()`,
+     `rewriteCanonicalReferences()`, `DtsPlugin()`
 
 2. **ApiModelOptions Interface** (`src/rslib/plugins/dts-plugin.ts`)
    - Purpose: Configuration for API model generation
@@ -74,7 +75,12 @@ bundled declarations and an API model file.
 
 ### Current Capabilities
 
-- Generate API model for main entry point ("." export only)
+- Generate API model for all entry points (multi-entry support)
+  - Per-entry API Extractor runs generate individual `.api.json` files
+  - `mergeApiModels()` combines per-entry models into a single Package
+    with multiple `EntryPoint` members
+  - Sub-entry canonical references scoped (e.g., `@scope/pkg/subpath!`)
+  - Single-entry packages use the API model as-is (no merge needed)
 - **API model enabled by default** (apiModel: true in DEFAULT_OPTIONS)
 - Exclude API model from npm publish via negated files array pattern
 - Copy API model to local paths for documentation development
@@ -209,19 +215,28 @@ no purpose. CI detection uses `CI` or `GITHUB_ACTIONS` environment variables.
 │                                                                 │
 │  ┌───────────────────────────┐    ┌─────────────────┐           │
 │  │   TsDocConfigBuilder      │    │ bundleDtsFiles  │           │
-│  │   .writeConfigFile()      │───▶│ ()              │           │
+│  │   .writeConfigFile()      │───▶│ (per entry)     │           │
 │  └───────────────────────────┘    └────────┬────────┘           │
 │                                            │                    │
+│                                   ┌────────┴────────┐           │
+│                                   │ mergeApiModels  │           │
+│                                   │ (multi-entry)   │           │
+│                                   └────────┬────────┘           │
 └────────────────────────────────────────────┼────────────────────┘
                                              │
                                              ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│                    API Extractor                                │
+│               API Extractor (per entry point)                   │
 │                                                                 │
-│  Inputs:                        Outputs:                        │
+│  Inputs:                        Outputs (per entry):            │
 │  - mainEntryPointFilePath       - bundled .d.ts                 │
-│  - tsdocConfigFile              - <package>.api.json            │
-│  - tsdocMetadata config         - tsdoc-metadata.json           │
+│  - tsdocConfigFile              - <entry>.api.json (temp)       │
+│  - tsdocMetadata config         - tsdoc-metadata.json (main)    │
+│                                                                 │
+│  After merge (multi-entry):     Final output:                   │
+│  - mergeApiModels() combines    - <package>.api.json            │
+│    per-entry models into one      (multiple EntryPoint members) │
+│    Package with N EntryPoints                                   │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -450,7 +465,7 @@ support declarations for each tag (defining tags isn't sufficient).
   "$schema": "https://developer.microsoft.com/...",
   "noStandardTags": false,
   "supportForTags": { "@param": true, "@returns": true, "..." },
-  "reportUnsupportedHtmlElements": false
+  "reportUnsupportedHtmlElements": true
 }
 ```
 
@@ -462,7 +477,7 @@ support declarations for each tag (defining tags isn't sufficient).
   "noStandardTags": false,
   "tagDefinitions": [{ "tagName": "@error", "syntaxKind": "inline" }],
   "supportForTags": { "@param": true, "...": true, "@error": true },
-  "reportUnsupportedHtmlElements": false
+  "reportUnsupportedHtmlElements": true
 }
 ```
 
@@ -474,7 +489,7 @@ support declarations for each tag (defining tags isn't sufficient).
   "noStandardTags": true,
   "tagDefinitions": [/* tags from enabled groups + custom */],
   "supportForTags": {/* tags from enabled groups, user overrides applied */},
-  "reportUnsupportedHtmlElements": false
+  "reportUnsupportedHtmlElements": true
 }
 ```
 
@@ -592,9 +607,11 @@ Integration with API Extractor is difficult to unit test. Rely on:
 
 ---
 
-**Document Status:** Current - All features implemented.
+**Document Status:** Current - All features implemented including multi-entry
+API model generation with per-entry API Extractor runs and model merging.
 
 **Implementation:**
 
 - TSDoc tag groups: Complete - See `tsdoc-configuration-support.md` plan
 - Config persistence: Complete - See `tsdoc-persist-config.md` plan
+- Multi-entry API model: Complete - Per-entry runs with `mergeApiModels()`

--- a/.claude/design/rslib-builder/api-model-options.md
+++ b/.claude/design/rslib-builder/api-model-options.md
@@ -3,8 +3,8 @@ status: current
 module: rslib-builder
 category: reference
 created: 2026-01-20
-updated: 2026-02-03
-last-synced: 2026-02-03
+updated: 2026-02-05
+last-synced: 2026-02-05
 completeness: 95
 related:
   - rslib-builder/architecture.md
@@ -486,12 +486,24 @@ export default NodeLibraryBuilder.create({
 
 ## Behavior Notes
 
-### API Model Generation Scope
+### Multi-Entry API Model Generation
 
-API models are only generated for the main "index" entry point (the "."
-export). Additional entry points like "./hooks" or "./utils" do not generate
-separate API models. This prevents multiple conflicting models and ensures a
-single source of truth.
+When a package has multiple entry points, API Extractor runs for each entry
+and generates a per-entry `.api.json` file in a temp directory. These are
+then merged into a single Package with multiple `EntryPoint` members via
+`mergeApiModels()`.
+
+**Single entry:** The per-entry API model is used as-is (no merge step).
+
+**Multiple entries:** Each per-entry model's `EntryPoint` is extracted,
+canonical references for sub-entries are rewritten to include the export
+subpath (e.g., `@scope/pkg/utils!` instead of `@scope/pkg!`), and all
+`EntryPoint` members are combined into one Package. The main entry (".")
+is always first in the members array.
+
+The `exportPaths` mapping from `EntryExtractor` provides the lossless
+reverse mapping from entry names back to original export keys for correct
+canonical reference scoping.
 
 ### File Distribution
 
@@ -500,6 +512,7 @@ single source of truth.
 | `<package>.api.json` | Yes | No (negated pattern) |
 | `tsdoc-metadata.json` | Yes | Yes (TSDoc spec requirement) |
 | `tsdoc.json` | Yes (if persist) | No (negated pattern) |
+| `tsconfig.json` | Yes (if apiModel) | No (negated pattern) |
 
 ### localPaths Behavior
 
@@ -549,4 +562,4 @@ explicitly defined.
 ---
 
 **Document Status:** Current - Comprehensive reference for ApiModelOptions
-configuration.
+configuration with multi-entry API model generation support.

--- a/.claude/design/rslib-builder/architecture.md
+++ b/.claude/design/rslib-builder/architecture.md
@@ -3,8 +3,8 @@ status: current
 module: rslib-builder
 category: architecture
 created: 2026-01-18
-updated: 2026-02-04
-last-synced: 2026-02-04
+updated: 2026-02-05
+last-synced: 2026-02-05
 completeness: 95
 related:
   - rslib-builder/api-extraction.md
@@ -147,6 +147,8 @@ processing stages.
   - Stages: modifyRsbuildConfig, pre-process, summarize, onCloseBuild
   - When apiModel enabled: emits tsconfig.json, api model, tsdoc-metadata.json
   - API model is enabled by default for npm target
+  - Multi-entry: runs API Extractor per entry, merges into single `.api.json`
+    with multiple `EntryPoint` members via `mergeApiModels()`
 - **PackageJsonTransformPlugin** - Transform package.json for dist
   - Stages: pre-process, optimize, optimize-inline
 - **FilesArrayPlugin** - Build package.json files array, exclude source maps
@@ -208,9 +210,14 @@ transformations. Consolidated from 14 files to 6 focused modules.
    - Logging: Shows which catalog each dependency was resolved from
      (e.g., `@microsoft/api-extractor: ^7.56.0 (catalog:silk)`)
 
-6. **`entry-extractor.ts`** - Entry point extraction (unchanged)
-   - Exports: `EntryExtractor` class
+6. **`entry-extractor.ts`** - Entry point extraction
+   - Exports: `EntryExtractor` class, `ExtractedEntries` interface
    - Class-based entry extraction from package.json exports/bin fields
+   - `ExtractedEntries` contains `entries` (name-to-source mapping) and
+     `exportPaths` (name-to-original-export-key mapping, e.g.,
+     `"nested-one"` -> `"./nested/one"`)
+   - `exportPaths` enables lossless reverse mapping for multi-entry API
+     model canonical references
 
 7. **`import-graph.ts`** - TypeScript import graph analysis
    - Exports: `ImportGraph` class, `ImportGraphOptions`, `ImportGraphResult`,
@@ -280,8 +287,6 @@ transformations. Consolidated from 14 files to 6 focused modules.
 
 - **No incremental type generation**: tsgo runs full compilation each build
 - **Sequential plugin stages**: Cannot parallelize cross-plugin operations
-- **Single entry bundled declarations**: API Extractor only bundles the main
-  entry point (".") declarations
 
 ---
 
@@ -955,22 +960,33 @@ Source .ts files
     .rslib/declarations/{target}/
          |
          v
-+--------------------------------+
-| API Extractor                  |
-|   - Bundle main entry .d.ts    |
-|   - Optional: Generate         |
-|     api.model.json             |
-+--------------------------------+
++----------------------------------------+
+| API Extractor (per entry point)        |
+|   - Bundle each entry's .d.ts          |
+|   - Generate per-entry .api.json       |
+|   - Generate tsdoc-metadata.json       |
+|     (main entry only)                  |
++----------------------------------------+
          |
          v
-+--------------------------------+
-| TsconfigResolver (if apiModel) |
-|   - Convert ParsedCommandLine  |
-|     to JSON-serializable       |
-|   - Set composite: false,      |
-|     noEmit: true               |
-|   - Emit tsconfig.json to dist |
-+--------------------------------+
++----------------------------------------+
+| mergeApiModels() (if multiple entries) |
+|   - Extract EntryPoint from each model |
+|   - Rewrite canonical references for   |
+|     sub-entries (e.g., @scope/pkg/sub!)|
+|   - Combine into single Package with   |
+|     multiple EntryPoint members        |
++----------------------------------------+
+         |
+         v
++----------------------------------------+
+| TsconfigResolver (if apiModel)         |
+|   - Convert ParsedCommandLine          |
+|     to JSON-serializable               |
+|   - Set composite: false,              |
+|     noEmit: true                       |
+|   - Emit tsconfig.json to dist         |
++----------------------------------------+
          |
          v
     Strip sourceMappingURL comments
@@ -994,10 +1010,15 @@ package.json
 |   - Parse bin field                    |
 |   - Map export keys to entry names     |
 |   - Resolve TS source paths            |
+|   - Build exportPaths mapping          |
+|     (entry name -> original export key)|
 +----------------------------------------+
          |
          v
-    entries: { "index": "./src/index.ts", ... }
+    ExtractedEntries: {
+      entries: { "index": "./src/index.ts", ... },
+      exportPaths: { "index": ".", "utils": "./utils", ... }
+    }
          |
          v
     Populate entrypoints Map
@@ -1369,8 +1390,6 @@ For comprehensive testing strategy details, see
 
 - **Incremental declaration caching**: Skip unchanged files in tsgo
 - **Parallel plugin stages**: Where dependencies allow
-- **Multi-entry declaration bundling**: Extend API Extractor to bundle all
-  entries
 
 ### Phase 2: Medium-term
 
@@ -1411,7 +1430,8 @@ For comprehensive testing strategy details, see
 ---
 
 **Document Status:** Current - Core architecture documented with all components
-including ImportGraph analysis, TsDocLintPlugin file discovery, and multi-
+including ImportGraph analysis, TsDocLintPlugin file discovery, multi-entry
+API model generation with per-entry API Extractor runs and merge, and multi-
 package-manager workspace catalog resolution (pnpm, yarn) with factory pattern
 for dependency injection
 

--- a/.claude/design/rslib-builder/testing-strategy.md
+++ b/.claude/design/rslib-builder/testing-strategy.md
@@ -3,8 +3,8 @@ status: current
 module: rslib-builder
 category: testing
 created: 2026-01-18
-updated: 2026-02-03
-last-synced: 2026-02-03
+updated: 2026-02-05
+last-synced: 2026-02-05
 completeness: 95
 related:
   - rslib-builder/architecture.md
@@ -76,8 +76,8 @@ src/
 │       ├── package-json-transform-plugin.ts
 │       ├── package-json-transform-plugin.test.ts
 │       └── utils/
-│           ├── pnpm-catalog.ts
-│           ├── pnpm-catalog.test.ts
+│           ├── workspace-catalog.ts
+│           ├── workspace-catalog.test.ts
 │           ├── asset-utils.ts
 │           ├── json-asset-utils.test.ts
 │           ├── asset-processor-utils.test.ts
@@ -117,7 +117,7 @@ Current test file inventory:
 | Plugins | `files-array-plugin.test.ts` | Package.json files array building |
 | Plugins | `package-json-transform-plugin.test.ts` | Package transformation |
 | Builders | `node-library-builder.test.ts` | Builder API and configuration |
-| Utils | `pnpm-catalog.test.ts` | PNPM catalog resolution |
+| Utils | `workspace-catalog.test.ts` | Workspace catalog resolution |
 | Utils | `json-asset-utils.test.ts` | JSON asset handling |
 | Utils | `asset-processor-utils.test.ts` | Asset processing pipeline |
 | Utils | `entry-extractor.test.ts` | Entry point extraction |
@@ -211,8 +211,8 @@ Co-located tests import the source file directly:
 // src/rslib/plugins/auto-entry-plugin.test.ts
 import { AutoEntryPlugin } from './auto-entry-plugin.js';
 
-// src/rslib/plugins/utils/pnpm-catalog.test.ts
-import { PnpmCatalog } from '#utils/pnpm-catalog.js';
+// src/rslib/plugins/utils/workspace-catalog.test.ts
+import { WorkspaceCatalog } from '#utils/workspace-catalog.js';
 ```
 
 ### Shared Utilities Import
@@ -423,7 +423,7 @@ vi.mock("@pnpm/exportable-manifest", () => ({
 }));
 
 // NOW import the module under test
-import { PnpmCatalog } from "#utils/pnpm-catalog.js";
+import { WorkspaceCatalog } from "#utils/workspace-catalog.js";
 ```
 
 ### Type-Safe Mock Access

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # Skip in CI environment
-[ -n "$GITHUB_ACTIONS" ] && exit 0
+[ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ] && exit 0
 
 # Get repo root directory
 ROOT=$(git rev-parse --show-toplevel)

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,29 +1,46 @@
-#!/bin/sh
+#!/usr/bin/env sh
+# Pre-commit hook with savvy-lint managed section
+# Custom hooks can go above or below the managed section
 
-# Skip pre-commit hook in CI environment
-[ -n "$GITHUB_ACTIONS" ] && exit 0
+# --- BEGIN SAVVY-LINT MANAGED SECTION ---
+# DO NOT EDIT between these markers - managed by savvy-lint
+# Skip in CI environment
+{ [ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ]; } && exit 0
 
-# Re-exec with zsh if not already running in zsh (for GUI git clients like GitKraken)
-if [ -z "$ZSH_VERSION" ]; then
-  exec /bin/zsh "$0" "$@"
-fi
+# Get repo root directory
+ROOT=$(git rev-parse --show-toplevel)
 
-# Skip pre-commit hook during rebase/squash operations (except final commit)
-[ -f ".git/rebase-merge/interactive" ] && exit 0
-[ -f ".git/rebase-apply/rebasing" ] && exit 0
+# Detect package manager from package.json or lockfiles
+detect_pm() {
+  # Check packageManager field in package.json (e.g., "pnpm@9.0.0")
+  if [ -f "$ROOT/package.json" ]; then
+    pm=$(jq -r '.packageManager // empty' "$ROOT/package.json" 2>/dev/null | cut -d'@' -f1)
+    if [ -n "$pm" ]; then
+      echo "$pm"
+      return
+    fi
+  fi
 
-# Ensure pnpm is in PATH for GUI git clients
-# Source user's zsh configuration to get full environment
-if [ -f "$HOME/.zshenv" ]; then
-  source "$HOME/.zshenv"
-fi
-if [ -n "$ZDOTDIR" ] && [ -f "$ZDOTDIR/.zshenv" ]; then
-  source "$ZDOTDIR/.zshenv"
-fi
+  # Fallback to lockfile detection
+  if [ -f "$ROOT/pnpm-lock.yaml" ]; then
+    echo "pnpm"
+  elif [ -f "$ROOT/yarn.lock" ]; then
+    echo "yarn"
+  elif [ -f "$ROOT/bun.lock" ]; then
+    echo "bun"
+  else
+    echo "npm"
+  fi
+}
 
-# Try to source nvm if available
-export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+# Get the exec command for the detected package manager
+PM=$(detect_pm)
+case "$PM" in
+  pnpm) CMD="pnpm exec" ;;
+  yarn) CMD="yarn exec" ;;
+  bun)  CMD="bunx" ;;
+  *)    CMD="npx --no --" ;;
+esac
 
-# Run lint-staged to check and fix staged files
-pnpm exec lint-staged --config ./lib/configs/lint-staged.config.ts
+$CMD lint-staged --config "$ROOT/lib/configs/lint-staged.config.ts"
+# --- END SAVVY-LINT MANAGED SECTION ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,15 @@
-# @savvy-web/rslib-builder - AI Agent Documentation
-
-This document provides guidance for AI agents working on the
-`@savvy-web/rslib-builder` package.
-
-## Package Overview
+# @savvy-web/rslib-builder
 
 RSlib-based build system for modern ESM Node.js libraries. Provides `NodeLibraryBuilder`
 API and plugin system for TypeScript packages.
+
+## Package Overview
 
 - Bundled ESM builds with rolled-up types
 - Multiple targets (dev and npm) with different optimizations
 - Automatic package.json transformation and pnpm catalog resolution
 - TypeScript declarations via tsgo + API Extractor
+- Multi-entry API model generation with per-entry canonical references
 - Self-building (uses NodeLibraryBuilder for its own build)
 
 ## Design Documentation
@@ -38,6 +36,36 @@ For API model generation and TSDoc configuration:
 - Debugging API Extractor output issues
 - Working with tsdoc.json or forgottenExports configuration
 
+For API model options and multi-entry configuration:
+
+--> `@./.claude/design/rslib-builder/api-model-options.md`
+
+**Load when:**
+
+- Configuring apiModel, tsdocMetadata, or localPaths options
+- Working with multi-entry API model merge behavior
+- Debugging API model output filenames or paths
+
+For virtual entry system:
+
+--> `@./.claude/design/rslib-builder/virtual-entries.md`
+
+**Load when:**
+
+- Working with the VirtualEntryPlugin or bundleless mode
+- Adding virtual entries to a build configuration
+- Debugging entry point resolution for non-TypeScript exports
+
+For testing strategy details:
+
+--> `@./.claude/design/rslib-builder/testing-strategy.md`
+
+**Load when:**
+
+- Writing new tests for plugins or utilities
+- Creating mock types for Rsbuild/Rspack APIs
+- Debugging coverage gaps or test failures
+
 ## Architecture
 
 ### Directory Structure
@@ -52,28 +80,24 @@ rslib-builder/
 │   │   │   └── node-library-builder.test.ts
 │   │   └── plugins/             # RSlib/Rsbuild plugins
 │   │       ├── auto-entry-plugin.ts
-│   │       ├── auto-entry-plugin.test.ts
 │   │       ├── dts-plugin.ts
-│   │       ├── dts-plugin.test.ts
 │   │       ├── files-array-plugin.ts
-│   │       ├── files-array-plugin.test.ts
 │   │       ├── package-json-transform-plugin.ts
-│   │       ├── package-json-transform-plugin.test.ts
 │   │       ├── tsdoc-lint-plugin.ts
-│   │       ├── tsdoc-lint-plugin.test.ts
+│   │       ├── virtual-entry-plugin.ts
 │   │       └── utils/           # Plugin utilities (with co-located tests)
 │   ├── tsconfig/                # TypeScript config templates
 │   ├── public/                  # Static files (tsconfig JSONs)
-│   ├── __test__/                # Shared test utilities
-│   │   └── rslib/
-│   │       ├── types/           # Test type definitions
-│   │       └── utils/           # Test helper functions
+│   ├── __test__/rslib/types/    # Shared test type definitions
 │   └── types/                   # TypeScript type definitions
+├── test/e2e/                    # E2E tests
 ├── rslib.config.ts              # Self-builds using NodeLibraryBuilder
 ├── package.json
 ├── tsconfig.json
 └── vitest.config.ts
 ```
+
+All plugins and utilities have co-located `.test.ts` files.
 
 ### Key Components
 
@@ -104,8 +128,10 @@ Custom RSlib plugins handle complex build scenarios:
 2. **AutoEntryPlugin** - Automatically extracts entry points from package.json exports
 3. **PackageJsonTransformPlugin** - Transforms package.json for different targets
 4. **DtsPlugin** - Generates TypeScript declarations using tsgo and API Extractor
+   - Runs API Extractor per entry, merges into single `.api.json` with multiple EntryPoints
    - When `apiModel` is enabled, also emits resolved `tsconfig.json` for virtual TS environments
 5. **FilesArrayPlugin** - Generates files array, excludes source maps
+6. **VirtualEntryPlugin** - Injects non-TypeScript virtual entries (JSON, static files)
 
 ### Build Targets
 
@@ -135,14 +161,6 @@ This module produces bundled ESM output with rolled-up types:
 - `tsdoc-metadata.json` - TSDoc metadata for downstream tools (published)
 - `tsconfig.json` - Resolved/flattened tsconfig for virtual TS environments (excluded from npm)
 
-The resolved tsconfig.json is configured for virtual environments:
-
-- Sets `composite: false` and `noEmit: true`
-- Excludes path-dependent options (outDir, rootDir, paths, typeRoots)
-- Excludes file selection (include, exclude, files)
-- Removes `types` array to use default @types auto-discovery
-- Includes `$schema` for IDE support
-
 ## Testing
 
 Tests are co-located with source files. Use type-safe mocks:
@@ -160,20 +178,14 @@ const mockAssets: MockAssetRegistry = {
 ### E2E Tests
 
 E2E tests verify builder options by building isolated fixture copies with
-dynamically generated configs. Located in `test/e2e/builder-options/`:
+dynamically generated configs:
 
-- `api-model.test.ts` - API model generation options
-- `build-options.test.ts` - General build options (externals, transform)
-- `tsdoc-lint.test.ts` - TSDoc lint configuration
-
-For testing strategy details:
---> `@./.claude/design/rslib-builder/testing-strategy.md`
-
-**Load when:**
-
-- Writing new tests for plugins or utilities
-- Creating mock types for Rsbuild/Rspack APIs
-- Debugging coverage gaps or test failures
+- `test/e2e/dts-bundling.test.ts` - DTS bundling for single/multi-entry fixtures
+- `test/e2e/builder-options/api-model.test.ts` - API model generation options
+- `test/e2e/builder-options/build-options.test.ts` - General build options (externals, transform)
+- `test/e2e/builder-options/format-option.test.ts` - Output format configuration
+- `test/e2e/builder-options/tsdoc-lint.test.ts` - TSDoc lint configuration
+- `test/e2e/builder-options/virtual-entries.test.ts` - Virtual entry injection
 
 ## Plugin Execution Order
 
@@ -186,15 +198,26 @@ Plugins execute in this order during the build:
 **Build Hooks:**
 
 1. AutoEntryPlugin (entry detection - `modifyRsbuildConfig`)
-2. DtsPlugin (type declarations - `pre-process` stage)
-3. PackageJsonTransformPlugin (package.json processing)
-4. FilesArrayPlugin (files array - `additional` stage)
+2. PackageJsonTransformPlugin (package.json processing)
+3. FilesArrayPlugin (files array - `additional` stage)
+4. DtsPlugin (type declarations - `pre-process` stage)
 5. User plugins (if provided)
+
+VirtualEntryPlugin runs in a separate Rslib environment for non-TypeScript entries.
 
 ## Development
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for development workflow, commands,
-and troubleshooting.
+Key commands:
+
+```bash
+pnpm build              # Build all targets
+pnpm test               # Run tests (verbose)
+pnpm lint:fix           # Auto-fix lint issues
+pnpm typecheck          # Type-check all workspaces
+```
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for full development workflow and
+troubleshooting.
 
 ## External Documentation
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ resolution automatically.
   Extractor for bundled, clean public API declarations
 - **Production-Ready Transforms** - Converts `.ts` exports to `.js`, resolves
   PNPM `catalog:` and `workspace:` references, generates files array
+- **Bundled or Bundleless** - Choose single-file bundles per entry or
+  bundleless mode that preserves your source file structure
 - **Multi-Target Builds** - Separate dev (with source maps) and npm (optimized)
   outputs from a single configuration
 - **TSDoc Validation** - Pre-build documentation validation with automatic

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ that simplifies building TypeScript packages for npm distribution.
 | Resolved tsconfig Export | Exports flattened tsconfig for virtual TS environments |
 | TSDoc Validation | Pre-build TSDoc comment validation (enabled by default) |
 | Package Transform | Resolves PNPM references, updates export paths |
+| Bundleless Mode | Preserve source file structure with hybrid DTS bundling |
 | Multi-Target | Separate dev (debugging) and npm (production) builds |
 | Virtual Entries | Bundle additional files with custom names (no types) |
 | Flexible Format | ESM or CJS output with per-entry format overrides |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -35,7 +35,7 @@ rslib-builder is organized into four conceptual layers:
                            ▼
 ┌─────────────────────────────────────────────────────────┐
 │              Plugin Orchestration Layer                 │
-│   - 4 specialized plugins                               │
+│   - 6 specialized plugins                               │
 │   - Sequential execution across build stages            │
 │   - Shared state via api.expose/api.useExposed          │
 └─────────────────────────────────────────────────────────┘
@@ -385,6 +385,21 @@ dist/npm/
 - **pnpmfile.cjs** - pnpm configuration hooks (must be CommonJS)
 - **CLI scripts** - Bundled executables not in package.json exports
 - **Config files** - Framework configuration files with specific requirements
+
+## Bundle Modes
+
+rslib-builder supports two JavaScript output modes:
+
+| Mode | JS Output | DTS Output | Config |
+| :--- | :-------- | :--------- | :----- |
+| Bundled (default) | Single file per entry | Bundled per entry | `bundle: true` |
+| Bundleless | Preserves file structure | Still bundled per entry | `bundle: false` |
+
+In bundleless mode, rslib-builder uses a hybrid approach: JavaScript files
+preserve the source directory structure while TypeScript declarations remain
+bundled per entry point via API Extractor. The builder uses `ImportGraph`
+to trace all files reachable from package.json exports and creates individual
+RSlib entries for each traced file.
 
 ## Build Targets
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -16,6 +16,7 @@ Complete reference for all `NodeLibraryBuilder` configuration options.
 - [ImportGraph Utility](#importgraph-utility)
 - [TsconfigResolver Utility](#tsconfigresolver-utility)
 - [EntryExtractor Utility](#entryextractor-utility)
+- [Bundle Mode](#bundle-mode)
 - [Define Constants](#define-constants)
 
 ## Basic Options
@@ -38,6 +39,7 @@ interface NodeLibraryBuilderOptions {
   apiModel?: ApiModelOptions | boolean;  // TSDoc lint is controlled via apiModel.tsdoc.lint
   format?: 'esm' | 'cjs';  // Output format, affects package.json type field
   virtualEntries?: Record<string, VirtualEntryConfig>;  // Additional bundled files
+  bundle?: boolean;  // Bundle JS into single files (true) or preserve file structure (false)
 }
 
 interface VirtualEntryConfig {
@@ -861,14 +863,14 @@ console.log(result.entries);
 // }
 ```
 
-### Functional Interface
+### One-Off Usage
 
-For one-off use, the functional interface is more convenient:
+For one-off use, you can create and immediately call the extractor:
 
 ```typescript
-import { extractEntriesFromPackageJson } from '@savvy-web/rslib-builder';
+import { EntryExtractor } from '@savvy-web/rslib-builder';
 
-const result = extractEntriesFromPackageJson(packageJson);
+const result = new EntryExtractor().extract(packageJson);
 ```
 
 ### EntryExtractorOptions
@@ -991,6 +993,64 @@ NodeLibraryBuilder.create({
   },
 });
 ```
+
+## Bundle Mode
+
+### bundle
+
+Control whether JavaScript output is bundled into single files per entry or
+preserves the source file structure.
+
+```typescript
+// Default: bundled output (single file per entry)
+NodeLibraryBuilder.create({
+  bundle: true,  // default
+});
+
+// Bundleless mode: preserve source file structure
+NodeLibraryBuilder.create({
+  bundle: false,
+});
+```
+
+| Value | JS Output | DTS Output | Use Case |
+| :---- | :-------- | :--------- | :------- |
+| `true` (default) | Single file per entry | Bundled per entry | Most libraries |
+| `false` | Preserves file structure | Still bundled per entry | Large libraries, tree-shaking |
+
+**How bundleless mode works:**
+
+When `bundle: false`, rslib-builder runs in a hybrid mode:
+
+- **JavaScript**: RSlib runs in bundleless mode, preserving your `src/` file
+  structure in the output. Each source file becomes a separate output file.
+- **TypeScript Declarations**: Still bundled per entry point via API Extractor.
+  This gives consumers clean, single-file type definitions.
+- **API Model**: When `apiModel` is enabled with multiple entries, per-entry
+  models are merged into a single `.api.json` with multiple `EntryPoint` members.
+
+**Entry resolution in bundleless mode:**
+
+In bundleless mode, rslib-builder uses `ImportGraph` to trace all files
+reachable from your package.json exports. Each traced file becomes an
+individual entry for RSlib, preserving the directory structure.
+
+```text
+src/                          dist/npm/
+├── index.ts          -->     ├── index.js
+├── utils/                    ├── index.d.ts
+│   ├── helpers.ts    -->     ├── utils/
+│   └── format.ts    -->     │   ├── helpers.js
+└── core/                     │   └── format.js
+    └── engine.ts    -->     └── core/
+                                  └── engine.js
+```
+
+**When to use bundleless mode:**
+
+- Libraries where consumers benefit from importing specific subpaths
+- Packages with many internal modules where tree-shaking is important
+- Projects that want to preserve source file organization in the output
 
 ## Define Constants
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -173,7 +173,7 @@ Key transformations:
 Now that you have a basic build working:
 
 - [Configuration Guide](./configuration.md) - Explore all options including
-  format selection and virtual entries
+  format selection, virtual entries, and bundleless mode
 - [Plugin System](./plugins.md) - Understand built-in plugins
 - [Architecture Overview](../architecture/overview.md) - Learn how it works
 - [Troubleshooting](../troubleshooting.md) - Solve common issues

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -335,6 +335,8 @@ Plugins execute in a specific order across Rsbuild's processing stages:
 2. processAssets: pre-process
    ├── PackageJsonTransformPlugin → Load files
    └── DtsPlugin                  → Generate .d.ts (skips virtual entries)
+                                    In bundleless mode: traces import graph,
+                                    bundles DTS per entry (hybrid approach)
 
 3. processAssets: optimize
    └── PackageJsonTransformPlugin → Transform package.json

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -344,6 +344,36 @@ virtualEntries: {
 Without explicit format, virtual entries inherit the top-level `format` option
 (default: `'esm'`).
 
+## Bundleless Mode Issues
+
+### Unexpected file structure in output
+
+**Symptom:** Output directory structure does not match source.
+
+**Common causes:**
+
+1. **Source files not reachable from exports**
+
+   In bundleless mode, rslib-builder uses `ImportGraph` to trace all files
+   from your package.json exports. Files not reachable through imports from
+   your entry points will not appear in the output.
+
+   **Solution:** Ensure all files you want in the output are imported
+   (directly or transitively) from an exported entry point.
+
+2. **`outBase` misconfiguration**
+
+   Bundleless mode sets `outBase` to `src` to preserve the source directory
+   structure. If your source files are not under `src/`, the output structure
+   may differ from expectations.
+
+### DTS still bundled in bundleless mode
+
+**Expected behavior:** This is by design. In bundleless mode, rslib-builder
+uses a hybrid approach where JavaScript preserves the file structure while
+TypeScript declarations are still bundled per entry point via API Extractor.
+This provides clean public API type definitions for consumers.
+
 ## Plugin Issues
 
 ### Custom plugin not running

--- a/lib/configs/lint-staged.config.ts
+++ b/lib/configs/lint-staged.config.ts
@@ -1,3 +1,3 @@
 import { Preset } from "@savvy-web/lint-staged";
 
-export default Preset.full();
+export default Preset.silk();

--- a/package.json
+++ b/package.json
@@ -86,31 +86,26 @@
 		"workspace-tools": "^0.41.0"
 	},
 	"devDependencies": {
-		"@changesets/cli": "^2.29.8",
-		"@microsoft/api-extractor": "^7.56.0",
+		"@changesets/cli": "catalog:silk",
 		"@pnpm/types": "^1001.3.0",
 		"@rsbuild/core": "^1.7.3",
-		"@rslib/core": "^0.19.4",
-		"@savvy-web/commitlint": "^0.2.0",
-		"@savvy-web/lint-staged": "^0.1.3",
+		"@savvy-web/commitlint": "^0.2.1",
+		"@savvy-web/lint-staged": "^0.2.1",
 		"@types/deep-equal": "^1.0.4",
-		"@types/node": "^25.2.0",
 		"@types/tmp": "^0.2.6",
-		"@typescript-eslint/parser": "^8.53.1",
-		"@typescript/native-preview": "7.0.0-dev.20260203.1",
+		"@typescript/native-preview": "catalog:silk",
 		"@vitest/coverage-v8": "^4.0.18",
-		"husky": "^9.1.7",
-		"turbo": "^2.8.2",
+		"turbo": "catalog:silk",
 		"type-fest": "^5.4.3",
-		"typescript": "^5.9.3",
-		"vitest": "^4.0.18"
+		"typescript": "catalog:silk",
+		"vitest": "catalog:silk"
 	},
 	"peerDependencies": {
-		"@microsoft/api-extractor": "^7.55.2",
-		"@rslib/core": "^0.19.3",
-		"@types/node": "^25.0.10",
-		"@typescript/native-preview": "^7.0.0-dev.20260124.1",
-		"typescript": "^5.9.3"
+		"@microsoft/api-extractor": "catalog:silk",
+		"@rslib/core": "catalog:silk",
+		"@types/node": "catalog:silk",
+		"@typescript/native-preview": "catalog:silk",
+		"typescript": "catalog:silk"
 	},
 	"peerDependenciesMeta": {
 		"@microsoft/api-extractor": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,13 +4,47 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  silk:
+    '@changesets/cli':
+      specifier: ^2.29.8
+      version: 2.29.8
+    '@microsoft/api-extractor':
+      specifier: ^7.56.2
+      version: 7.56.2
+    '@rslib/core':
+      specifier: ^0.19.4
+      version: 0.19.4
+    '@types/node':
+      specifier: ^25.2.0
+      version: 25.2.0
+    '@typescript/native-preview':
+      specifier: ^7.0.0-dev.20260203.1
+      version: 7.0.0-dev.20260203.1
+    turbo:
+      specifier: ^2.8.3
+      version: 2.8.3
+    typescript:
+      specifier: ^5.9.3
+      version: 5.9.3
+    vitest:
+      specifier: ^4.0.18
+      version: 4.0.18
+
 overrides:
-  lodash: ^=4.17.23
+  '@isaacs/brace-expansion': '>=5.0.1'
+  lodash: '>=4.17.23'
+  tmp: '>=0.2.4'
+
+pnpmfileChecksum: sha256-t6LF0gafv3q+GZ6ulKnfBQdWI84oVxZDQL2jtOFm5e4=
 
 importers:
 
   .:
     dependencies:
+      '@microsoft/api-extractor':
+        specifier: catalog:silk
+        version: 7.56.2(@types/node@25.2.0)
       '@microsoft/tsdoc':
         specifier: ^0.16.0
         version: 0.16.0
@@ -32,6 +66,12 @@ importers:
       '@pnpm/workspace.read-manifest':
         specifier: ^1000.2.10
         version: 1000.2.10
+      '@rslib/core':
+        specifier: catalog:silk
+        version: 0.19.4(@microsoft/api-extractor@7.56.2(@types/node@25.2.0))(@typescript/native-preview@7.0.0-dev.20260203.1)(typescript@5.9.3)
+      '@types/node':
+        specifier: catalog:silk
+        version: 25.2.0
       '@typescript-eslint/parser':
         specifier: ^8.53.1
         version: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
@@ -54,62 +94,50 @@ importers:
         specifier: ^3.6.1
         version: 3.6.1
       tmp:
-        specifier: ^0.2.5
+        specifier: '>=0.2.4'
         version: 0.2.5
       workspace-tools:
         specifier: ^0.41.0
         version: 0.41.0
     devDependencies:
       '@changesets/cli':
-        specifier: ^2.29.8
+        specifier: catalog:silk
         version: 2.29.8(@types/node@25.2.0)
-      '@microsoft/api-extractor':
-        specifier: ^7.56.0
-        version: 7.56.0(@types/node@25.2.0)
       '@pnpm/types':
         specifier: ^1001.3.0
         version: 1001.3.0
       '@rsbuild/core':
         specifier: ^1.7.3
         version: 1.7.3
-      '@rslib/core':
-        specifier: ^0.19.4
-        version: 0.19.4(@microsoft/api-extractor@7.56.0(@types/node@25.2.0))(@typescript/native-preview@7.0.0-dev.20260203.1)(typescript@5.9.3)
       '@savvy-web/commitlint':
-        specifier: ^0.2.0
-        version: 0.2.0(916e612cfbb68bc038a9b1bda5c95b52)
+        specifier: ^0.2.1
+        version: 0.2.1(0f6c4f3b8b14d08408d38a8755aa29cd)
       '@savvy-web/lint-staged':
-        specifier: ^0.1.3
-        version: 0.1.3(husky@9.1.7)(jiti@2.6.1)(lint-staged@16.2.7)(markdownlint-cli2-formatter-codequality@0.0.7(markdownlint-cli2@0.20.0))(markdownlint-cli2@0.20.0)(typescript@5.9.3)
+        specifier: ^0.2.1
+        version: 0.2.1(71f5906fb54d83f27c417fede8d14e27)
       '@types/deep-equal':
         specifier: ^1.0.4
         version: 1.0.4
-      '@types/node':
-        specifier: ^25.2.0
-        version: 25.2.0
       '@types/tmp':
         specifier: ^0.2.6
         version: 0.2.6
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260203.1
+        specifier: catalog:silk
         version: 7.0.0-dev.20260203.1
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2))
-      husky:
-        specifier: ^9.1.7
-        version: 9.1.7
       turbo:
-        specifier: ^2.8.2
-        version: 2.8.2
+        specifier: catalog:silk
+        version: 2.8.3
       type-fest:
         specifier: ^5.4.3
         version: 5.4.3
       typescript:
-        specifier: ^5.9.3
+        specifier: catalog:silk
         version: 5.9.3
       vitest:
-        specifier: ^4.0.18
+        specifier: catalog:silk
         version: 4.0.18(@types/node@25.2.0)(jiti@2.6.1)(yaml@2.8.2)
     publishDirectory: dist/dev
 
@@ -414,13 +442,13 @@ packages:
     resolution: {integrity: sha512-aO5l99BQJ0X34ft8b0h7QFkQlqxC6e7ZPVmBKz13xM9O8obDaM1Cld4sQlJDXXU/VFuUzQ30mVtHjVz74TuStw==}
     engines: {node: '>=v18'}
 
-  '@effect/cli@0.73.1':
-    resolution: {integrity: sha512-lKDNq1Dwb+f1aPbse+EPORbNhQSJvefkEeFiIdWQJB4YX/D/9cibGGA1rb4A1PHn8qJhrE376DG3d0TlszxR+w==}
+  '@effect/cli@0.73.2':
+    resolution: {integrity: sha512-K8IJo81+qa1LU8dhxcDU4QO/bIjL/dPd3zUOSCpLiuUNz8Y3/T+WNs3GqIXEhMfCFMSlRZERN0YgmtRlEZUREA==}
     peerDependencies:
-      '@effect/platform': ^0.94.2
+      '@effect/platform': ^0.94.3
       '@effect/printer': ^0.47.0
       '@effect/printer-ansi': ^0.47.0
-      effect: ^3.19.15
+      effect: ^3.19.16
 
   '@effect/cluster@0.56.1':
     resolution: {integrity: sha512-gnrsH6kfrUjn+82j/bw1IR4yFqJqV8tc7xZvrbJPRgzANycc6K1hu3LMg548uYbUkTzD8YYyqrSatMO1mkQpzw==}
@@ -462,10 +490,10 @@ packages:
       '@effect/sql': ^0.49.0
       effect: ^3.19.15
 
-  '@effect/platform@0.94.2':
-    resolution: {integrity: sha512-85vdwpnK4oH/rJ3EuX/Gi2Hkt+K4HvXWr9bxCuqvty9hxyEcRxkJcqTesYrcVoQB6aULb1Za2B0MKoTbvffB3Q==}
+  '@effect/platform@0.94.3':
+    resolution: {integrity: sha512-bvTR8xLQoRpKgHuprZDOeQdPkhyVw+WT05iI9jl2s8Qiblyk5Dz2JLwJU+EFeksIBaPYz49xa635Om91T1CefQ==}
     peerDependencies:
-      effect: ^3.19.15
+      effect: ^3.19.16
 
   '@effect/printer-ansi@0.47.0':
     resolution: {integrity: sha512-tDEQ9XJpXDNYoWMQJHFRMxKGmEOu6z32x3Kb8YLOV5nkauEKnKmWNs7NBp8iio/pqoJbaSwqDwUg9jXVquxfWQ==}
@@ -741,10 +769,6 @@ packages:
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
 
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
-    engines: {node: 20 || >=22}
-
   '@isaacs/brace-expansion@5.0.1':
     resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
     engines: {node: 20 || >=22}
@@ -770,6 +794,10 @@ packages:
 
   '@microsoft/api-extractor@7.56.0':
     resolution: {integrity: sha512-H0V69QG5jIb9Ayx35NVBv2lOgFSS3q+Eab2oyGEy0POL3ovYPST+rCNPbwYoczOZXNG8IKjWUmmAMxmDTsXlQA==}
+    hasBin: true
+
+  '@microsoft/api-extractor@7.56.2':
+    resolution: {integrity: sha512-d94f7S+H43jDxY/YIyp5UOE9N12HZmEPP5Ct96us+fw1FVKBoy4itTopdVM1VrcpduuA7fK/t31CgA2jM8AqSA==}
     hasBin: true
 
   '@microsoft/tsdoc-config@0.18.0':
@@ -1314,8 +1342,11 @@ packages:
   '@rushstack/ts-command-line@5.1.7':
     resolution: {integrity: sha512-Ugwl6flarZcL2nqH5IXFYk3UR3mBVDsVFlCQW/Oaqidvdb/5Ota6b/Z3JXWIdqV3rOR2/JrYoAHanWF5rgenXA==}
 
-  '@savvy-web/commitlint@0.2.0':
-    resolution: {integrity: sha512-sKK4o9hlu2qc1aKulCAyj256Q8LnlGaEmeijRZ0OVZ3f9d+2Cr0uXtdZTRHgK5AKbQ5GVEI99rtnf8QscPhCww==}
+  '@rushstack/ts-command-line@5.2.0':
+    resolution: {integrity: sha512-lYxCX0nDdkDtCkVpvF0m25ymf66SaMWuppbD6b7MdkIzvGXKBXNIVZlwBH/C0YfkanrupnICWf2n4z3AKSfaHw==}
+
+  '@savvy-web/commitlint@0.2.1':
+    resolution: {integrity: sha512-DQ6M6cQ8kmZesVEb5XiQ3CJwXW13L6VMI7Lo6TvFoFd7/mdKnVE6mpVcbTqIF9pk4GItQZo8bnnTIXBc790dwA==}
     hasBin: true
     peerDependencies:
       '@commitlint/cli': ^20.4.1
@@ -1326,8 +1357,9 @@ packages:
       commitizen:
         optional: true
 
-  '@savvy-web/lint-staged@0.1.3':
-    resolution: {integrity: sha512-BX1tS9nkuvK5huikZhaeS3TCGNSwqNf9Bo+Q/CQd7QAUJNxmEbQoMWpwPlLpnOwS88jwFVl98EAb7urKDcukow==}
+  '@savvy-web/lint-staged@0.2.1':
+    resolution: {integrity: sha512-lwx2ITQgWbRyMNh+e6k61+KQ/hHQ08Zfj82OwaPArLKdOpjoThdSq8LQUPTkdreq39DzyF9RJTc15F/UHzPAYQ==}
+    hasBin: true
     peerDependencies:
       '@biomejs/biome': ^2.3.12
       husky: ^9.1.7
@@ -1602,8 +1634,8 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
-  ansi-escapes@7.2.0:
-    resolution: {integrity: sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==}
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
 
   ansi-regex@5.0.1:
@@ -1857,8 +1889,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  effect@3.19.15:
-    resolution: {integrity: sha512-vzMmgfZKLcojmUjBdlQx+uaKryO7yULlRxjpDnHdnvcp1NPHxJyoM6IOXBLlzz2I/uPtZpGKavt5hBv7IvGZkA==}
+  effect@3.19.16:
+    resolution: {integrity: sha512-7+XC3vGrbAhCHd8LTFHvnZjRpZKZ8YHRZqJTkpNoxcJ2mCyNs2SwI+6VkV/ij8Y3YW7wfBN4EbU06/F5+m/wkQ==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -2967,6 +2999,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -3167,38 +3204,38 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  turbo-darwin-64@2.8.2:
-    resolution: {integrity: sha512-sumREbxABHxrWIwlK67sZEaDRE7+BFSU8gZj8OK+X7dLpgW1vTjsHzTECB5m2qzWlXHRdueAk8sKv7wyHqv9jw==}
+  turbo-darwin-64@2.8.3:
+    resolution: {integrity: sha512-4kXRLfcygLOeNcP6JquqRLmGB/ATjjfehiojL2dJkL7GFm3SPSXbq7oNj8UbD8XriYQ5hPaSuz59iF1ijPHkTw==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.8.2:
-    resolution: {integrity: sha512-J3zoDkf+k9yozdJmdNUOc9YfIoFs01Zm+GgNyfY8pU6siMWlPlgdt+3ezbIMeOns6CAQUzUcqo9awowykAS9Vw==}
+  turbo-darwin-arm64@2.8.3:
+    resolution: {integrity: sha512-xF7uCeC0UY0Hrv/tqax0BMbFlVP1J/aRyeGQPZT4NjvIPj8gSPDgFhfkfz06DhUwDg5NgMo04uiSkAWE8WB/QQ==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.8.2:
-    resolution: {integrity: sha512-iVYUM+tyNAPd34HhMSjYWi7OSXnxnDhPjFKVvzSb7cZmQS6GlDSr7MALc5Wt/zn6/7jm1FuS7c5Wffg9WD2e1Q==}
+  turbo-linux-64@2.8.3:
+    resolution: {integrity: sha512-vxMDXwaOjweW/4etY7BxrXCSkvtwh0PbwVafyfT1Ww659SedUxd5rM3V2ZCmbwG8NiCfY7d6VtxyHx3Wh1GoZA==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.8.2:
-    resolution: {integrity: sha512-v7FJAHUhY2nSEE87mr5ZBO51GmsFKp0EmK2P6rO+vGimCPmnGlLNj1at/eVcnp/cHRDnJj8J+b3QHWdUzTPTkg==}
+  turbo-linux-arm64@2.8.3:
+    resolution: {integrity: sha512-mQX7uYBZFkuPLLlKaNe9IjR1JIef4YvY8f21xFocvttXvdPebnq3PK1Zjzl9A1zun2BEuWNUwQIL8lgvN9Pm3Q==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.8.2:
-    resolution: {integrity: sha512-d1X+U5JLhyAse0VXM0rpmu6iLbBTAvjwc7MX0PBkEaTz2aZQqOHBpQkkrxia7bZzRNbfXHbGSqY/vbE3GSFWzw==}
+  turbo-windows-64@2.8.3:
+    resolution: {integrity: sha512-YLGEfppGxZj3VWcNOVa08h6ISsVKiG85aCAWosOKNUjb6yErWEuydv6/qImRJUI+tDLvDvW7BxopAkujRnWCrw==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.8.2:
-    resolution: {integrity: sha512-fMln07/l/5kscs79V0kTwdf17gkZW+E2iyqnzz691gLM7Jf6la0afd3IMsNtLzUh+dxKIFCswNiFVmHe8g+2jA==}
+  turbo-windows-arm64@2.8.3:
+    resolution: {integrity: sha512-afTUGKBRmOJU1smQSBnFGcbq0iabAPwh1uXu2BVk7BREg30/1gMnJh9DFEQTah+UD3n3ru8V55J83RQNFfqoyw==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.8.2:
-    resolution: {integrity: sha512-biW/S5hENCcJ5vxxJszCozEKcXtwGK29vxXzNbdfY/0q7QpYTCoyKdj0e8k/ADA6qkqaKDJwgrrHbC8Vy6wszg==}
+  turbo@2.8.3:
+    resolution: {integrity: sha512-8Osxz5Tu/Dw2kb31EAY+nhq/YZ3wzmQSmYa1nIArqxgCAldxv9TPlrAiaBUDVnKA4aiPn0OFBD1ACcpc5VFOAQ==}
     hasBin: true
 
   type-check@0.4.0:
@@ -3487,7 +3524,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.7.3
+      semver: 7.7.4
 
   '@changesets/assemble-release-plan@6.0.9':
     dependencies:
@@ -3496,7 +3533,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.7.3
+      semver: 7.7.4
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -3529,7 +3566,7 @@ snapshots:
       package-manager-detector: 0.2.11
       picocolors: 1.1.1
       resolve-from: 5.0.0
-      semver: 7.7.3
+      semver: 7.7.4
       spawndamnit: 3.0.1
       term-size: 2.2.1
     transitivePeerDependencies:
@@ -3554,7 +3591,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.7.3
+      semver: 7.7.4
 
   '@changesets/get-release-plan@4.0.14':
     dependencies:
@@ -3659,7 +3696,7 @@ snapshots:
   '@commitlint/is-ignored@20.4.1':
     dependencies:
       '@commitlint/types': 20.4.0
-      semver: 7.7.3
+      semver: 7.7.4
 
   '@commitlint/lint@20.4.1':
     dependencies:
@@ -3726,53 +3763,53 @@ snapshots:
       conventional-commits-parser: 6.2.1
       picocolors: 1.1.1
 
-  '@effect/cli@0.73.1(@effect/platform@0.94.2(effect@3.19.15))(@effect/printer-ansi@0.47.0(@effect/typeclass@0.38.0(effect@3.19.15))(effect@3.19.15))(@effect/printer@0.47.0(@effect/typeclass@0.38.0(effect@3.19.15))(effect@3.19.15))(effect@3.19.15)':
+  '@effect/cli@0.73.2(@effect/platform@0.94.3(effect@3.19.16))(@effect/printer-ansi@0.47.0(@effect/typeclass@0.38.0(effect@3.19.16))(effect@3.19.16))(@effect/printer@0.47.0(@effect/typeclass@0.38.0(effect@3.19.16))(effect@3.19.16))(effect@3.19.16)':
     dependencies:
-      '@effect/platform': 0.94.2(effect@3.19.15)
-      '@effect/printer': 0.47.0(@effect/typeclass@0.38.0(effect@3.19.15))(effect@3.19.15)
-      '@effect/printer-ansi': 0.47.0(@effect/typeclass@0.38.0(effect@3.19.15))(effect@3.19.15)
-      effect: 3.19.15
+      '@effect/platform': 0.94.3(effect@3.19.16)
+      '@effect/printer': 0.47.0(@effect/typeclass@0.38.0(effect@3.19.16))(effect@3.19.16)
+      '@effect/printer-ansi': 0.47.0(@effect/typeclass@0.38.0(effect@3.19.16))(effect@3.19.16)
+      effect: 3.19.16
       ini: 4.1.3
       toml: 3.0.0
       yaml: 2.8.2
 
-  '@effect/cluster@0.56.1(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(effect@3.19.15))(effect@3.19.15)':
+  '@effect/cluster@0.56.1(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(effect@3.19.16))(effect@3.19.16)':
     dependencies:
-      '@effect/platform': 0.94.2(effect@3.19.15)
-      '@effect/rpc': 0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15)
-      '@effect/sql': 0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15)
-      '@effect/workflow': 0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(effect@3.19.15)
-      effect: 3.19.15
+      '@effect/platform': 0.94.3(effect@3.19.16)
+      '@effect/rpc': 0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16)
+      '@effect/sql': 0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16)
+      '@effect/workflow': 0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(effect@3.19.16)
+      effect: 3.19.16
       kubernetes-types: 1.30.0
 
-  '@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15)':
+  '@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16)':
     dependencies:
-      '@effect/platform': 0.94.2(effect@3.19.15)
-      effect: 3.19.15
+      '@effect/platform': 0.94.3(effect@3.19.16)
+      effect: 3.19.16
       uuid: 11.1.0
 
-  '@effect/platform-node-shared@0.57.1(@effect/cluster@0.56.1(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(effect@3.19.15)':
+  '@effect/platform-node-shared@0.57.1(@effect/cluster@0.56.1(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(effect@3.19.16)':
     dependencies:
-      '@effect/cluster': 0.56.1(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(effect@3.19.15))(effect@3.19.15)
-      '@effect/platform': 0.94.2(effect@3.19.15)
-      '@effect/rpc': 0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15)
-      '@effect/sql': 0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15)
+      '@effect/cluster': 0.56.1(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(effect@3.19.16))(effect@3.19.16)
+      '@effect/platform': 0.94.3(effect@3.19.16)
+      '@effect/rpc': 0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16)
+      '@effect/sql': 0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16)
       '@parcel/watcher': 2.5.6
-      effect: 3.19.15
+      effect: 3.19.16
       multipasta: 0.2.7
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@0.104.1(@effect/cluster@0.56.1(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(effect@3.19.15)':
+  '@effect/platform-node@0.104.1(@effect/cluster@0.56.1(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(effect@3.19.16)':
     dependencies:
-      '@effect/cluster': 0.56.1(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(effect@3.19.15))(effect@3.19.15)
-      '@effect/platform': 0.94.2(effect@3.19.15)
-      '@effect/platform-node-shared': 0.57.1(@effect/cluster@0.56.1(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(effect@3.19.15)
-      '@effect/rpc': 0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15)
-      '@effect/sql': 0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15)
-      effect: 3.19.15
+      '@effect/cluster': 0.56.1(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(effect@3.19.16))(effect@3.19.16)
+      '@effect/platform': 0.94.3(effect@3.19.16)
+      '@effect/platform-node-shared': 0.57.1(@effect/cluster@0.56.1(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(effect@3.19.16)
+      '@effect/rpc': 0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16)
+      '@effect/sql': 0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16)
+      effect: 3.19.16
       mime: 3.0.0
       undici: 7.20.0
       ws: 8.19.0
@@ -3780,47 +3817,47 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform@0.94.2(effect@3.19.15)':
+  '@effect/platform@0.94.3(effect@3.19.16)':
     dependencies:
-      effect: 3.19.15
+      effect: 3.19.16
       find-my-way-ts: 0.1.6
       msgpackr: 1.11.8
       multipasta: 0.2.7
 
-  '@effect/printer-ansi@0.47.0(@effect/typeclass@0.38.0(effect@3.19.15))(effect@3.19.15)':
+  '@effect/printer-ansi@0.47.0(@effect/typeclass@0.38.0(effect@3.19.16))(effect@3.19.16)':
     dependencies:
-      '@effect/printer': 0.47.0(@effect/typeclass@0.38.0(effect@3.19.15))(effect@3.19.15)
-      '@effect/typeclass': 0.38.0(effect@3.19.15)
-      effect: 3.19.15
+      '@effect/printer': 0.47.0(@effect/typeclass@0.38.0(effect@3.19.16))(effect@3.19.16)
+      '@effect/typeclass': 0.38.0(effect@3.19.16)
+      effect: 3.19.16
 
-  '@effect/printer@0.47.0(@effect/typeclass@0.38.0(effect@3.19.15))(effect@3.19.15)':
+  '@effect/printer@0.47.0(@effect/typeclass@0.38.0(effect@3.19.16))(effect@3.19.16)':
     dependencies:
-      '@effect/typeclass': 0.38.0(effect@3.19.15)
-      effect: 3.19.15
+      '@effect/typeclass': 0.38.0(effect@3.19.16)
+      effect: 3.19.16
 
-  '@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15)':
+  '@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16)':
     dependencies:
-      '@effect/platform': 0.94.2(effect@3.19.15)
-      effect: 3.19.15
+      '@effect/platform': 0.94.3(effect@3.19.16)
+      effect: 3.19.16
       msgpackr: 1.11.8
 
-  '@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15)':
+  '@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16)':
     dependencies:
-      '@effect/experimental': 0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15)
-      '@effect/platform': 0.94.2(effect@3.19.15)
-      effect: 3.19.15
+      '@effect/experimental': 0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16)
+      '@effect/platform': 0.94.3(effect@3.19.16)
+      effect: 3.19.16
       uuid: 11.1.0
 
-  '@effect/typeclass@0.38.0(effect@3.19.15)':
+  '@effect/typeclass@0.38.0(effect@3.19.16)':
     dependencies:
-      effect: 3.19.15
+      effect: 3.19.16
 
-  '@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(effect@3.19.15)':
+  '@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(effect@3.19.16)':
     dependencies:
-      '@effect/experimental': 0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15)
-      '@effect/platform': 0.94.2(effect@3.19.15)
-      '@effect/rpc': 0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15)
-      effect: 3.19.15
+      '@effect/experimental': 0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16)
+      '@effect/platform': 0.94.3(effect@3.19.16)
+      '@effect/rpc': 0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16)
+      effect: 3.19.16
 
   '@emnapi/core@1.8.1':
     dependencies:
@@ -3984,10 +4021,6 @@ snapshots:
 
   '@isaacs/balanced-match@4.0.1': {}
 
-  '@isaacs/brace-expansion@5.0.0':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
-
   '@isaacs/brace-expansion@5.0.1':
     dependencies:
       '@isaacs/balanced-match': 4.0.1
@@ -4037,6 +4070,25 @@ snapshots:
       diff: 8.0.3
       lodash: 4.17.23
       minimatch: 10.0.3
+      resolve: 1.22.11
+      semver: 7.5.4
+      source-map: 0.6.1
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/api-extractor@7.56.2(@types/node@25.2.0)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.32.2(@types/node@25.2.0)
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.0
+      '@rushstack/node-core-library': 5.19.1(@types/node@25.2.0)
+      '@rushstack/rig-package': 0.6.0
+      '@rushstack/terminal': 0.21.0(@types/node@25.2.0)
+      '@rushstack/ts-command-line': 5.2.0(@types/node@25.2.0)
+      diff: 8.0.3
+      lodash: 4.17.23
+      minimatch: 10.1.2
       resolve: 1.22.11
       semver: 7.5.4
       source-map: 0.6.1
@@ -4446,6 +4498,16 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript/native-preview'
 
+  '@rslib/core@0.19.4(@microsoft/api-extractor@7.56.2(@types/node@25.2.0))(@typescript/native-preview@7.0.0-dev.20260203.1)(typescript@5.9.3)':
+    dependencies:
+      '@rsbuild/core': 1.7.3
+      rsbuild-plugin-dts: 0.19.4(@microsoft/api-extractor@7.56.2(@types/node@25.2.0))(@rsbuild/core@1.7.3)(@typescript/native-preview@7.0.0-dev.20260203.1)(typescript@5.9.3)
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.56.2(@types/node@25.2.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@typescript/native-preview'
+
   '@rspack/binding-darwin-arm64@1.7.5':
     optional: true
 
@@ -4540,14 +4602,23 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@savvy-web/commitlint@0.2.0(916e612cfbb68bc038a9b1bda5c95b52)':
+  '@rushstack/ts-command-line@5.2.0(@types/node@25.2.0)':
+    dependencies:
+      '@rushstack/terminal': 0.21.0(@types/node@25.2.0)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@savvy-web/commitlint@0.2.1(0f6c4f3b8b14d08408d38a8755aa29cd)':
     dependencies:
       '@commitlint/cli': 20.4.1(@types/node@25.2.0)(typescript@5.9.3)
       '@commitlint/config-conventional': 20.4.1
-      '@effect/cli': 0.73.1(@effect/platform@0.94.2(effect@3.19.15))(@effect/printer-ansi@0.47.0(@effect/typeclass@0.38.0(effect@3.19.15))(effect@3.19.15))(@effect/printer@0.47.0(@effect/typeclass@0.38.0(effect@3.19.15))(effect@3.19.15))(effect@3.19.15)
-      '@effect/platform': 0.94.2(effect@3.19.15)
-      '@effect/platform-node': 0.104.1(@effect/cluster@0.56.1(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(@effect/rpc@0.73.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(@effect/platform@0.94.2(effect@3.19.15))(effect@3.19.15))(effect@3.19.15)
-      effect: 3.19.15
+      '@effect/cli': 0.73.2(@effect/platform@0.94.3(effect@3.19.16))(@effect/printer-ansi@0.47.0(@effect/typeclass@0.38.0(effect@3.19.16))(effect@3.19.16))(@effect/printer@0.47.0(@effect/typeclass@0.38.0(effect@3.19.16))(effect@3.19.16))(effect@3.19.16)
+      '@effect/platform': 0.94.3(effect@3.19.16)
+      '@effect/platform-node': 0.104.1(@effect/cluster@0.56.1(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(effect@3.19.16)
+      effect: 3.19.16
       husky: 9.1.7
       workspace-tools: 0.40.4
       zod: 4.3.6
@@ -4560,10 +4631,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@savvy-web/lint-staged@0.1.3(husky@9.1.7)(jiti@2.6.1)(lint-staged@16.2.7)(markdownlint-cli2-formatter-codequality@0.0.7(markdownlint-cli2@0.20.0))(markdownlint-cli2@0.20.0)(typescript@5.9.3)':
+  '@savvy-web/lint-staged@0.2.1(71f5906fb54d83f27c417fede8d14e27)':
     dependencies:
+      '@effect/cli': 0.73.2(@effect/platform@0.94.3(effect@3.19.16))(@effect/printer-ansi@0.47.0(@effect/typeclass@0.38.0(effect@3.19.16))(effect@3.19.16))(@effect/printer@0.47.0(@effect/typeclass@0.38.0(effect@3.19.16))(effect@3.19.16))(effect@3.19.16)
+      '@effect/platform': 0.94.3(effect@3.19.16)
+      '@effect/platform-node': 0.104.1(@effect/cluster@0.56.1(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.3(effect@3.19.16))(effect@3.19.16))(effect@3.19.16)
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       cosmiconfig: 9.0.0(typescript@5.9.3)
+      effect: 3.19.16
       eslint: 9.39.2(jiti@2.6.1)
       eslint-plugin-tsdoc: 0.5.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       husky: 9.1.7
@@ -4571,12 +4646,19 @@ snapshots:
       markdownlint-cli2: 0.20.0
       markdownlint-cli2-formatter-codequality: 0.0.7(markdownlint-cli2@0.20.0)
       sort-package-json: 3.6.1
-      workspace-tools: 0.40.4
+      workspace-tools: 0.41.0
       yaml: 2.8.2
     transitivePeerDependencies:
+      - '@effect/cluster'
+      - '@effect/printer'
+      - '@effect/printer-ansi'
+      - '@effect/rpc'
+      - '@effect/sql'
+      - bufferutil
       - jiti
       - supports-color
       - typescript
+      - utf-8-validate
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
@@ -4872,7 +4954,7 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
-  ansi-escapes@7.2.0:
+  ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
 
@@ -5120,7 +5202,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  effect@3.19.15:
+  effect@3.19.16:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
@@ -5767,7 +5849,7 @@ snapshots:
 
   log-update@6.1.0:
     dependencies:
-      ansi-escapes: 7.2.0
+      ansi-escapes: 7.3.0
       cli-cursor: 5.0.0
       slice-ansi: 7.1.2
       strip-ansi: 7.1.2
@@ -6033,7 +6115,7 @@ snapshots:
 
   minimatch@10.0.3:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      '@isaacs/brace-expansion': 5.0.1
 
   minimatch@10.1.2:
     dependencies:
@@ -6328,6 +6410,15 @@ snapshots:
       '@typescript/native-preview': 7.0.0-dev.20260203.1
       typescript: 5.9.3
 
+  rsbuild-plugin-dts@0.19.4(@microsoft/api-extractor@7.56.2(@types/node@25.2.0))(@rsbuild/core@1.7.3)(@typescript/native-preview@7.0.0-dev.20260203.1)(typescript@5.9.3):
+    dependencies:
+      '@ast-grep/napi': 0.37.0
+      '@rsbuild/core': 1.7.3
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.56.2(@types/node@25.2.0)
+      '@typescript/native-preview': 7.0.0-dev.20260203.1
+      typescript: 5.9.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -6351,6 +6442,8 @@ snapshots:
       lru-cache: 6.0.0
 
   semver@7.7.3: {}
+
+  semver@7.7.4: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -6540,32 +6633,32 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  turbo-darwin-64@2.8.2:
+  turbo-darwin-64@2.8.3:
     optional: true
 
-  turbo-darwin-arm64@2.8.2:
+  turbo-darwin-arm64@2.8.3:
     optional: true
 
-  turbo-linux-64@2.8.2:
+  turbo-linux-64@2.8.3:
     optional: true
 
-  turbo-linux-arm64@2.8.2:
+  turbo-linux-arm64@2.8.3:
     optional: true
 
-  turbo-windows-64@2.8.2:
+  turbo-windows-64@2.8.3:
     optional: true
 
-  turbo-windows-arm64@2.8.2:
+  turbo-windows-arm64@2.8.3:
     optional: true
 
-  turbo@2.8.2:
+  turbo@2.8.3:
     optionalDependencies:
-      turbo-darwin-64: 2.8.2
-      turbo-darwin-arm64: 2.8.2
-      turbo-linux-64: 2.8.2
-      turbo-linux-arm64: 2.8.2
-      turbo-windows-64: 2.8.2
-      turbo-windows-arm64: 2.8.2
+      turbo-darwin-64: 2.8.3
+      turbo-darwin-arm64: 2.8.3
+      turbo-linux-64: 2.8.3
+      turbo-linux-arm64: 2.8.3
+      turbo-windows-64: 2.8.3
+      turbo-windows-arm64: 2.8.3
 
   type-check@0.4.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,14 +1,15 @@
 packages:
   - .
   - test/fixtures/*
+configDependencies:
+  "@savvy-web/pnpm-plugin-silk": 0.3.0+sha512-jOHtsax1haxeFFfpKUaEV2U0qY4cwNmGLNls4h2K4oRMP+9FHyuVd6e0v1Dcx1olKOK8C89rgOYSsWs0PwVhWA==
 loglevel: info
 onlyBuiltDependencies:
   - "@parcel/watcher"
+  - "@savvy-web/lint-staged"
   - core-js
   - esbuild
   - msgpackr-extract
-overrides:
-  lodash: ^=4.17.23
 preferFrozenLockfile: true
 publicHoistPattern:
   - "@commitlint/cli"

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -2,6 +2,7 @@ import { NodeLibraryBuilder } from "./src/index.js";
 
 // Use our own builder - self-building example
 export default NodeLibraryBuilder.create({
+	bundle: true,
 	// Generate API model for npm target (used by documentation tooling)
 	// Set RSLIB_BUILDER_LOCAL_PATH env var for local API model path resolution
 	apiModel: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ export type { TsDocLintPluginOptions } from "./rslib/plugins/tsdoc-lint-plugin.j
 export { TsDocLintPlugin } from "./rslib/plugins/tsdoc-lint-plugin.js";
 // Utilities - Entry Extraction
 export type { EntryExtractorOptions, ExtractedEntries } from "./rslib/plugins/utils/entry-extractor.js";
-export { EntryExtractor, extractEntriesFromPackageJson } from "./rslib/plugins/utils/entry-extractor.js";
+export { EntryExtractor } from "./rslib/plugins/utils/entry-extractor.js";
 // Utilities - Import Graph Analysis
 export type {
 	ImportGraphError,

--- a/src/rslib/builders/node-library-builder.test.ts
+++ b/src/rslib/builders/node-library-builder.test.ts
@@ -1,21 +1,82 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import type { RslibConfig } from "@rslib/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NodeLibraryBuilder } from "./node-library-builder.js";
 
 // Mock node:fs
 vi.mock("node:fs", () => ({
 	existsSync: vi.fn(),
+	readFileSync: vi.fn(),
 }));
 
 // Mock node:path
-vi.mock("node:path", () => ({
-	join: vi.fn((...args: string[]) => args.join("/")),
+vi.mock("node:path", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:path")>();
+	return {
+		...actual,
+		join: vi.fn((...args: string[]) => args.join("/")),
+	};
+});
+
+// Capture defineConfig args
+let capturedConfig: RslibConfig | undefined;
+vi.mock("@rslib/core", () => ({
+	defineConfig: vi.fn((config: RslibConfig) => {
+		capturedConfig = config;
+		return config;
+	}),
 }));
+
+// Mock plugins to return identifiable objects
+vi.mock("../plugins/auto-entry-plugin.js", () => ({
+	AutoEntryPlugin: vi.fn((opts: unknown) => ({ name: "auto-entry-plugin", _opts: opts })),
+}));
+vi.mock("../plugins/dts-plugin.js", () => ({
+	DtsPlugin: vi.fn(() => ({ name: "dts-plugin" })),
+}));
+vi.mock("../plugins/files-array-plugin.js", () => ({
+	FilesArrayPlugin: vi.fn(() => ({ name: "files-array-plugin" })),
+}));
+vi.mock("../plugins/package-json-transform-plugin.js", () => ({
+	PackageJsonTransformPlugin: vi.fn(() => ({ name: "package-json-transform-plugin" })),
+}));
+vi.mock("../plugins/tsdoc-lint-plugin.js", () => ({
+	TsDocLintPlugin: vi.fn(() => ({ name: "tsdoc-lint-plugin" })),
+}));
+vi.mock("../plugins/virtual-entry-plugin.js", () => ({
+	VirtualEntryPlugin: vi.fn(() => ({ name: "virtual-entry-plugin" })),
+}));
+vi.mock("../plugins/utils/file-utils.js", () => ({
+	packageJsonVersion: vi.fn().mockResolvedValue("1.0.0"),
+}));
+
+// Mock import graph for bundleless entry computation
+const mockTraceFromEntries = vi.fn().mockReturnValue({
+	files: ["/test/cwd/src/index.ts"],
+	entries: ["/test/cwd/src/index.ts"],
+	errors: [],
+});
+vi.mock("../plugins/utils/import-graph.js", () => ({
+	ImportGraph: class MockImportGraph {
+		traceFromEntries = mockTraceFromEntries;
+	},
+}));
+vi.mock("../plugins/utils/entry-extractor.js", () => ({
+	EntryExtractor: class MockEntryExtractor {
+		extract = vi.fn().mockReturnValue({
+			entries: { index: "./src/index.ts" },
+		});
+	},
+}));
+
+// Import mocked AutoEntryPlugin to inspect calls
+import { AutoEntryPlugin } from "../plugins/auto-entry-plugin.js";
 
 describe("NodeLibraryBuilder", () => {
 	beforeEach(() => {
-		vi.resetAllMocks();
+		vi.clearAllMocks();
+		capturedConfig = undefined;
 	});
 
 	describe("DEFAULT_OPTIONS", () => {
@@ -28,6 +89,7 @@ describe("NodeLibraryBuilder", () => {
 				targets: ["dev", "npm"],
 				externals: [],
 				apiModel: true,
+				bundle: true,
 			});
 		});
 	});
@@ -130,6 +192,115 @@ describe("NodeLibraryBuilder", () => {
 			});
 
 			expect(result.targets).toEqual(["npm"]);
+		});
+
+		it("should default bundle to true", () => {
+			vi.mocked(existsSync).mockReturnValue(false);
+
+			const result = NodeLibraryBuilder.mergeOptions();
+
+			expect(result.bundle).toBe(true);
+		});
+
+		it("should preserve bundle: false when explicitly set", () => {
+			vi.mocked(existsSync).mockReturnValue(false);
+
+			const result = NodeLibraryBuilder.mergeOptions({
+				bundle: false,
+			});
+
+			expect(result.bundle).toBe(false);
+		});
+
+		it("should preserve bundle: true when explicitly set", () => {
+			vi.mocked(existsSync).mockReturnValue(false);
+
+			const result = NodeLibraryBuilder.mergeOptions({
+				bundle: true,
+			});
+
+			expect(result.bundle).toBe(true);
+		});
+	});
+
+	describe("createSingleTarget", () => {
+		const mockPackageJson = JSON.stringify({
+			name: "test-pkg",
+			version: "1.0.0",
+			exports: { ".": "./src/index.ts" },
+		});
+
+		beforeEach(() => {
+			vi.mocked(existsSync).mockReturnValue(false);
+			vi.mocked(readFileSync).mockReturnValue(mockPackageJson);
+		});
+
+		it("should set outBase to outputDir when bundle is true", async () => {
+			const options = NodeLibraryBuilder.mergeOptions({ bundle: true });
+			await NodeLibraryBuilder.createSingleTarget("npm", options);
+
+			const lib = capturedConfig?.lib?.[0];
+			expect(lib).toBeDefined();
+			expect(lib?.outBase).toBe("dist/npm");
+		});
+
+		it("should set outBase to 'src' when bundle is false", async () => {
+			const options = NodeLibraryBuilder.mergeOptions({ bundle: false });
+			await NodeLibraryBuilder.createSingleTarget("npm", options);
+
+			const lib = capturedConfig?.lib?.[0];
+			expect(lib).toBeDefined();
+			expect(lib?.outBase).toBe("src");
+		});
+
+		it("should pass bundleless: true to AutoEntryPlugin when bundle is false", async () => {
+			const options = NodeLibraryBuilder.mergeOptions({ bundle: false });
+			await NodeLibraryBuilder.createSingleTarget("npm", options);
+
+			expect(AutoEntryPlugin).toHaveBeenCalledWith(expect.objectContaining({ bundleless: true }));
+		});
+
+		it("should not pass bundleless to AutoEntryPlugin when bundle is true", async () => {
+			const options = NodeLibraryBuilder.mergeOptions({ bundle: true });
+			await NodeLibraryBuilder.createSingleTarget("npm", options);
+
+			// Should be called with empty object (no bundleless key)
+			const callArgs = vi.mocked(AutoEntryPlugin).mock.calls[0][0];
+			expect(callArgs).toBeDefined();
+			expect(callArgs).not.toHaveProperty("bundleless");
+		});
+
+		it("should pass both bundleless and exportsAsIndexes when both are set", async () => {
+			const options = NodeLibraryBuilder.mergeOptions({ bundle: false, exportsAsIndexes: true });
+			await NodeLibraryBuilder.createSingleTarget("npm", options);
+
+			expect(AutoEntryPlugin).toHaveBeenCalledWith(
+				expect.objectContaining({ bundleless: true, exportsAsIndexes: true }),
+			);
+		});
+
+		it("should set bundle: false on lib config when bundle option is false", async () => {
+			const options = NodeLibraryBuilder.mergeOptions({ bundle: false });
+			await NodeLibraryBuilder.createSingleTarget("npm", options);
+
+			const lib = capturedConfig?.lib?.[0];
+			expect(lib?.bundle).toBe(false);
+		});
+
+		it("should set legalComments to 'inline' when bundle is false", async () => {
+			const options = NodeLibraryBuilder.mergeOptions({ bundle: false });
+			await NodeLibraryBuilder.createSingleTarget("npm", options);
+
+			const lib = capturedConfig?.lib?.[0];
+			expect(lib?.output?.legalComments).toBe("inline");
+		});
+
+		it("should not set legalComments when bundle is true", async () => {
+			const options = NodeLibraryBuilder.mergeOptions({ bundle: true });
+			await NodeLibraryBuilder.createSingleTarget("npm", options);
+
+			const lib = capturedConfig?.lib?.[0];
+			expect(lib?.output?.legalComments).toBeUndefined();
 		});
 	});
 });

--- a/src/rslib/builders/node-library-builder.ts
+++ b/src/rslib/builders/node-library-builder.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import type { RsbuildPlugin, SourceConfig } from "@rsbuild/core";
 import type { ConfigParams, LibConfig, RslibConfig } from "@rslib/core";
 import { defineConfig } from "@rslib/core";
@@ -11,7 +11,9 @@ import { FilesArrayPlugin } from "../plugins/files-array-plugin.js";
 import { PackageJsonTransformPlugin } from "../plugins/package-json-transform-plugin.js";
 import type { TsDocLintPluginOptions } from "../plugins/tsdoc-lint-plugin.js";
 import { TsDocLintPlugin } from "../plugins/tsdoc-lint-plugin.js";
+import { EntryExtractor } from "../plugins/utils/entry-extractor.js";
 import { packageJsonVersion } from "../plugins/utils/file-utils.js";
+import { ImportGraph } from "../plugins/utils/import-graph.js";
 import { VirtualEntryPlugin } from "../plugins/virtual-entry-plugin.js";
 
 /**
@@ -429,6 +431,20 @@ export interface NodeLibraryBuilderOptions {
 	 * ```
 	 */
 	apiModel?: ApiModelOptions | boolean;
+
+	/**
+	 * Whether to bundle JavaScript output into single files per entry point.
+	 *
+	 * @remarks
+	 * - `true` (default): RSlib bundles JS into single files per entry (current behavior)
+	 * - `false`: RSlib runs in bundleless mode, preserving file structure for JS output.
+	 *   DTS is still bundled per entry via API Extractor (hybrid mode).
+	 *   When `apiModel` is enabled with multiple entries, per-entry API models are
+	 *   merged into a single `api.model.json` with multiple EntryPoint members.
+	 *
+	 * @defaultValue true
+	 */
+	bundle?: boolean;
 }
 
 /**
@@ -504,6 +520,7 @@ export class NodeLibraryBuilder {
 		targets: ["dev", "npm"],
 		externals: [],
 		apiModel: true,
+		bundle: true,
 	} satisfies Partial<NodeLibraryBuilderOptions>;
 
 	/**
@@ -536,6 +553,7 @@ export class NodeLibraryBuilder {
 			targets: options.targets ?? NodeLibraryBuilder.DEFAULT_OPTIONS.targets,
 			externals: options.externals ?? NodeLibraryBuilder.DEFAULT_OPTIONS.externals,
 			apiModel: options.apiModel ?? NodeLibraryBuilder.DEFAULT_OPTIONS.apiModel,
+			bundle: options.bundle ?? NodeLibraryBuilder.DEFAULT_OPTIONS.bundle,
 			// Optional properties - only include if explicitly defined
 			...(options.entry !== undefined && { entry: options.entry }),
 			...(options.exportsAsIndexes !== undefined && { exportsAsIndexes: options.exportsAsIndexes }),
@@ -615,13 +633,21 @@ export class NodeLibraryBuilder {
 				// Add lint-specific options if provided
 				...(typeof lintConfig === "object" ? lintConfig : {}),
 			};
-			plugins.push(TsDocLintPlugin(lintOptions));
+			plugins.push(
+				TsDocLintPlugin({
+					...lintOptions,
+					...(options.bundle === false && { perEntry: true }),
+				}),
+			);
 		}
 
 		// Add auto-entry plugin if no explicit entries provided
 		if (!options.entry) {
 			plugins.push(
-				AutoEntryPlugin(options.exportsAsIndexes != null ? { exportsAsIndexes: options.exportsAsIndexes } : undefined),
+				AutoEntryPlugin({
+					...(options.exportsAsIndexes != null && { exportsAsIndexes: options.exportsAsIndexes }),
+					...(options.bundle === false && { bundleless: true }),
+				}),
 			);
 		}
 
@@ -633,10 +659,15 @@ export class NodeLibraryBuilder {
 		// Get format (defaults to "esm")
 		const libraryFormat = options.format ?? "esm";
 
+		// collapseIndex: bundle || !exportsAsIndexes
+		// In bundleless mode with exportsAsIndexes, keep ./foo/index.js paths
+		// In bundleless mode without exportsAsIndexes, collapse ./foo/index.ts → ./foo.js
+		const collapseIndex = (options.bundle ?? true) || !(options.exportsAsIndexes ?? false);
+
 		plugins.push(
 			PackageJsonTransformPlugin({
 				forcePrivate: target === "dev",
-				bundle: true,
+				bundle: collapseIndex,
 				target,
 				format: libraryFormat,
 				...(transformFn && { transform: transformFn }),
@@ -652,14 +683,29 @@ export class NodeLibraryBuilder {
 		);
 
 		// Add user-provided plugins
-		if (options.plugins) {
-			plugins.push(...options.plugins);
-		}
+		plugins.push(...options.plugins);
 
 		// Build output configuration
 		const outputDir = `dist/${target}`;
 
-		const entry = options.entry;
+		// In bundleless mode, compute traced entries from import graph so RSlib
+		// receives them on the lib config (modifyRsbuildConfig is too late —
+		// RSlib resolves entries before plugin hooks run)
+		let entry = options.entry;
+		if (options.bundle === false && !entry) {
+			const cwd = process.cwd();
+			const packageJsonPath = join(cwd, "package.json");
+			const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as PackageJson;
+			const { entries } = new EntryExtractor().extract(packageJson);
+			const graph = new ImportGraph({ rootDir: cwd });
+			const result = graph.traceFromEntries(Object.values(entries));
+			const tracedEntries: Record<string, string> = {};
+			for (const file of result.files) {
+				const relPath = relative(cwd, file);
+				tracedEntries[relPath] = `./${relPath}`;
+			}
+			entry = tracedEntries;
+		}
 
 		// Add our custom DTS plugin that uses tsgo and emits through asset pipeline
 		// The plugin will generate the temp tsconfig itself since it needs access to api.context.rootPath
@@ -670,7 +716,7 @@ export class NodeLibraryBuilder {
 			DtsPlugin({
 				...(options.tsconfigPath && { tsconfigPath: options.tsconfigPath }),
 				abortOnError: true,
-				bundle: true,
+				bundle: options.bundle ?? true,
 				...(options.dtsBundledPackages && { bundledPackages: options.dtsBundledPackages }),
 				buildTarget: target,
 				format: libraryFormat,
@@ -680,12 +726,14 @@ export class NodeLibraryBuilder {
 
 		const lib: LibConfig = {
 			id: target,
-			outBase: outputDir,
+			outBase: options.bundle === false ? "src" : outputDir,
 			output: {
 				target: "node",
 				module: true,
 				cleanDistPath: true,
 				sourceMap: target === "dev", // Only enable source maps for dev target
+				// Prevent @preserve comments from generating .LICENSE.txt files
+				...(options.bundle === false && { legalComments: "inline" as const }),
 				distPath: {
 					root: outputDir,
 				},
@@ -698,7 +746,7 @@ export class NodeLibraryBuilder {
 			experiments: {
 				advancedEsm: libraryFormat === "esm",
 			},
-			bundle: true,
+			bundle: options.bundle ?? true,
 			plugins,
 			source: {
 				// Don't set tsconfigPath here - DtsPlugin will generate and use its own temp config
@@ -744,15 +792,14 @@ export class NodeLibraryBuilder {
 
 			for (const [outputName, config] of Object.entries(virtualEntries)) {
 				const entryFormat = config.format ?? libraryFormat;
-				if (!virtualByFormat.has(entryFormat)) {
-					virtualByFormat.set(entryFormat, new Map());
+				let formatMap = virtualByFormat.get(entryFormat);
+				if (!formatMap) {
+					formatMap = new Map();
+					virtualByFormat.set(entryFormat, formatMap);
 				}
 				// Strip extension from output name to get entry name
 				const entryName = outputName.replace(/\.(c|m)?js$/, "");
-				const formatMap = virtualByFormat.get(entryFormat);
-				if (formatMap) {
-					formatMap.set(entryName, config.source);
-				}
+				formatMap.set(entryName, config.source);
 			}
 
 			// Create lib configs for each format group
@@ -830,9 +877,7 @@ export class NodeLibraryBuilder {
 			const packageJsonPath = join(process.cwd(), "package.json");
 			const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as PackageJson;
 			const { exports } = packageJson;
-			return (
-				exports !== undefined && exports !== null && typeof exports === "object" && Object.keys(exports).length > 0
-			);
+			return exports != null && typeof exports === "object" && Object.keys(exports).length > 0;
 		} catch {
 			return false;
 		}

--- a/src/rslib/plugins/auto-entry-plugin.test.ts
+++ b/src/rslib/plugins/auto-entry-plugin.test.ts
@@ -22,6 +22,14 @@ vi.mock("../../src/tsconfig/plugins/utils/logger-utils.js", () => ({
 	}),
 }));
 
+// Mock ImportGraph for bundleless tests
+const mockTraceFromEntries = vi.fn();
+vi.mock("./utils/import-graph.js", () => ({
+	ImportGraph: class MockImportGraph {
+		traceFromEntries = mockTraceFromEntries;
+	},
+}));
+
 const mockReadFile: ReturnType<typeof vi.mocked<typeof readFile>> = vi.mocked(readFile);
 const mockAccess: ReturnType<typeof vi.mocked<typeof access>> = vi.mocked(access);
 const mockStat: ReturnType<typeof vi.mocked<typeof stat>> = vi.mocked(stat);
@@ -419,5 +427,165 @@ describe("AutoEntryPlugin", () => {
 		>;
 		// Map should be empty since exports is an array
 		expect(exportToOutputMap.size).toBe(0);
+	});
+
+	describe("bundleless mode", () => {
+		it("should trace import graph and set entry to traced file list", async () => {
+			const packageJson: PackageJson = {
+				name: "test-package",
+				version: "1.0.0",
+				exports: {
+					".": "./src/index.ts",
+					"./utils": "./src/utils/index.ts",
+				},
+			};
+
+			// Mock package.json to exist
+			mockStat.mockResolvedValue(createMockStats(new Date()));
+			mockAccess.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue(JSON.stringify(packageJson));
+
+			// Mock import graph tracing results
+			mockTraceFromEntries.mockReturnValue({
+				files: [
+					"/test/project/src/helpers.ts",
+					"/test/project/src/index.ts",
+					"/test/project/src/utils/index.ts",
+					"/test/project/src/utils/shared.ts",
+				],
+				entries: ["/test/project/src/index.ts", "/test/project/src/utils/index.ts"],
+				errors: [],
+			});
+
+			const plugin = AutoEntryPlugin({ bundleless: true });
+			const mockApi = {
+				modifyRsbuildConfig: vi.fn(),
+				expose: vi.fn(),
+				useExposed: vi.fn().mockReturnValue(undefined),
+				onBeforeBuild: vi.fn(),
+				logger: {
+					debug: vi.fn(),
+				},
+			};
+
+			plugin.setup(mockApi as unknown as Parameters<ReturnType<typeof AutoEntryPlugin>["setup"]>[0]);
+
+			const configModifier = mockApi.modifyRsbuildConfig.mock.calls[0][0];
+			const config = {
+				environments: {
+					development: { source: {} },
+				},
+			};
+
+			await configModifier(config);
+
+			// Verify import graph was called with entry source paths
+			expect(mockTraceFromEntries).toHaveBeenCalledWith(["./src/index.ts", "./src/utils/index.ts"]);
+
+			// Verify source.entry is set to individual named entries (one per traced file)
+			const devEntry = (config.environments.development.source as { entry?: Record<string, string> }).entry;
+			expect(devEntry).toEqual({
+				"src/helpers.ts": "./src/helpers.ts",
+				"src/index.ts": "./src/index.ts",
+				"src/utils/index.ts": "./src/utils/index.ts",
+				"src/utils/shared.ts": "./src/utils/shared.ts",
+			});
+		});
+
+		it("should still expose named entries via entrypoints map in bundleless mode", async () => {
+			const packageJson: PackageJson = {
+				name: "test-package",
+				version: "1.0.0",
+				exports: {
+					".": "./src/index.ts",
+					"./utils": "./src/utils/index.ts",
+				},
+			};
+
+			mockStat.mockResolvedValue(createMockStats(new Date()));
+			mockAccess.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue(JSON.stringify(packageJson));
+
+			mockTraceFromEntries.mockReturnValue({
+				files: ["/test/project/src/index.ts", "/test/project/src/utils/index.ts"],
+				entries: ["/test/project/src/index.ts", "/test/project/src/utils/index.ts"],
+				errors: [],
+			});
+
+			const plugin = AutoEntryPlugin({ bundleless: true });
+			const mockApi = {
+				modifyRsbuildConfig: vi.fn(),
+				expose: vi.fn(),
+				useExposed: vi.fn().mockReturnValue(undefined),
+				onBeforeBuild: vi.fn(),
+				logger: {
+					debug: vi.fn(),
+				},
+			};
+
+			plugin.setup(mockApi as unknown as Parameters<ReturnType<typeof AutoEntryPlugin>["setup"]>[0]);
+
+			// Get the entrypoints map that was exposed
+			const entrypointsMap = mockApi.expose.mock.calls.find((call) => call[0] === "entrypoints")?.[1] as Map<
+				string,
+				string
+			>;
+
+			const configModifier = mockApi.modifyRsbuildConfig.mock.calls[0][0];
+			const config = {
+				environments: {
+					development: { source: {} },
+				},
+			};
+
+			await configModifier(config);
+
+			// Named entries should still be in entrypoints map (for DtsPlugin, PackageJsonTransformPlugin)
+			expect(entrypointsMap.has("index.ts")).toBe(true);
+			expect(entrypointsMap.get("index.ts")).toBe("./src/index.ts");
+			expect(entrypointsMap.has("utils.ts")).toBe(true);
+			expect(entrypointsMap.get("utils.ts")).toBe("./src/utils/index.ts");
+		});
+
+		it("should not trace import graph when bundleless is not set", async () => {
+			const packageJson: PackageJson = {
+				name: "test-package",
+				version: "1.0.0",
+				exports: "./src/index.ts",
+			};
+
+			mockStat.mockResolvedValue(createMockStats(new Date()));
+			mockAccess.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue(JSON.stringify(packageJson));
+
+			const plugin = AutoEntryPlugin();
+			const mockApi = {
+				modifyRsbuildConfig: vi.fn(),
+				expose: vi.fn(),
+				useExposed: vi.fn().mockReturnValue(undefined),
+				onBeforeBuild: vi.fn(),
+				logger: {
+					debug: vi.fn(),
+				},
+			};
+
+			plugin.setup(mockApi as unknown as Parameters<ReturnType<typeof AutoEntryPlugin>["setup"]>[0]);
+
+			const configModifier = mockApi.modifyRsbuildConfig.mock.calls[0][0];
+			const config = {
+				environments: {
+					development: { source: {} },
+				},
+			};
+
+			await configModifier(config);
+
+			// Import graph should NOT be used in non-bundleless mode
+			expect(mockTraceFromEntries).not.toHaveBeenCalled();
+
+			// Entries should be named entries (not traced file list)
+			const devEntry = (config.environments.development.source as { entry?: Record<string, string> }).entry;
+			expect(devEntry).toEqual({ index: "./src/index.ts" });
+		});
 	});
 });

--- a/src/rslib/plugins/auto-entry-plugin.ts
+++ b/src/rslib/plugins/auto-entry-plugin.ts
@@ -1,9 +1,11 @@
 import { readFile } from "node:fs/promises";
+import { relative } from "node:path";
 import type { RsbuildPlugin, RsbuildPluginAPI } from "@rsbuild/core";
 import type { PackageJson } from "../../types/package-json.js";
 import { createEnvLogger } from "./utils/build-logger.js";
-import { extractEntriesFromPackageJson } from "./utils/entry-extractor.js";
+import { EntryExtractor } from "./utils/entry-extractor.js";
 import { fileExistAsync } from "./utils/file-utils.js";
+import { ImportGraph } from "./utils/import-graph.js";
 
 /**
  * Options for the AutoEntryPlugin.
@@ -40,6 +42,19 @@ export interface AutoEntryPluginOptions {
 	 * @defaultValue false
 	 */
 	exportsAsIndexes?: boolean;
+
+	/**
+	 * When enabled, uses import graph analysis to discover all reachable files
+	 * from entry points, and sets RSlib's source.entry to the traced file list
+	 * instead of named entries.
+	 *
+	 * @remarks
+	 * Named entries are still exposed via the `entrypoints` map for DtsPlugin
+	 * and PackageJsonTransformPlugin to use.
+	 *
+	 * @defaultValue false
+	 */
+	bundleless?: boolean;
 }
 
 /**
@@ -124,10 +139,9 @@ export const AutoEntryPlugin = (options?: AutoEntryPluginOptions): RsbuildPlugin
 					const packageJson = JSON.parse(packageJsonContent) as PackageJson;
 
 					// Extract entries from package.json exports and bin fields
-					const { entries } = extractEntriesFromPackageJson(
-						packageJson,
-						options?.exportsAsIndexes != null ? { exportsAsIndexes: options.exportsAsIndexes } : undefined,
-					);
+					const extractorOptions =
+						options?.exportsAsIndexes != null ? { exportsAsIndexes: options.exportsAsIndexes } : undefined;
+					const { entries } = new EntryExtractor(extractorOptions).extract(packageJson);
 
 					// When exportsAsIndexes is enabled, build a mapping from export keys to output paths
 					if (options?.exportsAsIndexes && packageJson.exports) {
@@ -142,7 +156,7 @@ export const AutoEntryPlugin = (options?: AutoEntryPluginOptions): RsbuildPlugin
 								const normalizedExportKey = pkgExportKey.replace(/^\.\//, "");
 
 								// Find the matching entry
-								for (const [entryName] of Object.entries(entries)) {
+								for (const entryName of Object.keys(entries)) {
 									// The entry name might be "vscode/settings/index" and export key is "./vscode/settings"
 									const normalizedEntryName = entryName.replace(/\/index$/, "");
 
@@ -170,16 +184,43 @@ export const AutoEntryPlugin = (options?: AutoEntryPluginOptions): RsbuildPlugin
 					if (Object.keys(entries).length > 0) {
 						const environments = Object.entries(config?.environments ?? {});
 
-						// Apply entries to each environment
-						environments.forEach(([_env, lib]) => {
-							lib.source = {
-								...lib.source,
-								entry: {
-									...lib.source?.entry,
-									...entries,
-								},
-							};
-						});
+						// In bundleless mode, trace import graph and use all reachable files
+						// Named entries are still exposed via entrypoints map above
+						if (options?.bundleless) {
+							const cwd = process.cwd();
+							const graph = new ImportGraph({ rootDir: cwd });
+							const entrySourcePaths = Object.values(entries);
+							const result = graph.traceFromEntries(entrySourcePaths);
+							const tracedEntries: Record<string, string> = {};
+							for (const file of result.files) {
+								const relPath = relative(cwd, file);
+								tracedEntries[relPath] = `./${relPath}`;
+							}
+
+							log.global.info(
+								`bundleless: traced ${Object.keys(tracedEntries).length} files from ${entrySourcePaths.length} entries`,
+							);
+
+							// Replace entry entirely with traced files — don't spread existing
+							// entry which may contain RSlib's default "src/**" glob
+							environments.forEach(([_env, lib]) => {
+								lib.source = {
+									...lib.source,
+									entry: tracedEntries,
+								};
+							});
+						} else {
+							// Apply named entries to each environment
+							environments.forEach(([_env, lib]) => {
+								lib.source = {
+									...lib.source,
+									entry: {
+										...lib.source?.entry,
+										...entries,
+									},
+								};
+							});
+						}
 
 						// Log entries only once per build process
 						const state = buildStateMap.get(api);

--- a/src/rslib/plugins/dts-plugin.test.ts
+++ b/src/rslib/plugins/dts-plugin.test.ts
@@ -11,6 +11,7 @@ import {
 	generateTsgoArgs,
 	getTsgoBinPath,
 	getUnscopedPackageName,
+	mergeApiModels,
 	stripSourceMapComment,
 } from "./dts-plugin.js";
 
@@ -761,7 +762,7 @@ export declare const bar: number;`);
 			const config = TsDocConfigBuilder.buildConfigObject();
 			expect(config.$schema).toBe("https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json");
 			expect(config.noStandardTags).toBe(false);
-			expect(config.reportUnsupportedHtmlElements).toBe(false);
+			expect(config.reportUnsupportedHtmlElements).toBe(true);
 		});
 
 		it("should include tagDefinitions for custom tags", () => {
@@ -824,6 +825,193 @@ export declare const bar: number;`);
 			const expectedConfig = TsDocConfigBuilder.buildConfigObject({});
 			await writeFile(configPath, JSON.stringify(expectedConfig));
 			await expect(TsDocConfigBuilder.validateConfigFile({}, configPath)).resolves.toBeUndefined();
+		});
+	});
+
+	describe("mergeApiModels", () => {
+		/**
+		 * Creates a mock API model matching API Extractor's actual output structure.
+		 * The root object is the Package (kind: "Package"), whose `members` array
+		 * contains a single EntryPoint (kind: "EntryPoint").
+		 */
+		function makeApiModel(options: {
+			packageName: string;
+			entryName: string;
+			members?: unknown[];
+		}): Record<string, unknown> {
+			return {
+				metadata: { toolPackage: "@microsoft/api-extractor", toolVersion: "7.50.0" },
+				kind: "Package",
+				canonicalReference: `${options.packageName}!`,
+				name: options.packageName,
+				preserveMemberOrder: false,
+				members: [
+					{
+						kind: "EntryPoint",
+						canonicalReference: `${options.packageName}!`,
+						name: "",
+						members: options.members ?? [
+							{
+								kind: "Function",
+								canonicalReference: `${options.packageName}!myFunc:function(1)`,
+								docComment: "/** A function */\n",
+								excerptTokens: [],
+								name: "myFunc",
+							},
+						],
+					},
+				],
+			};
+		}
+
+		it("should pass through single entry model unchanged", () => {
+			const model = makeApiModel({ packageName: "@scope/pkg", entryName: "index" });
+			const perEntryModels = new Map([["index", model]]);
+
+			const result = mergeApiModels({
+				perEntryModels,
+				packageName: "@scope/pkg",
+				exportPaths: { index: "." },
+			});
+
+			// Root is the Package; members are EntryPoints
+			expect(result.kind).toBe("Package");
+			const entryPoints = result.members as Record<string, unknown>[];
+			expect(entryPoints).toHaveLength(1);
+
+			expect(entryPoints[0].kind).toBe("EntryPoint");
+			expect(entryPoints[0].canonicalReference).toBe("@scope/pkg!");
+			expect(entryPoints[0].name).toBe("");
+		});
+
+		it("should merge multiple entries with correct canonical references", () => {
+			const mainModel = makeApiModel({ packageName: "@scope/pkg", entryName: "index" });
+			const utilsModel = makeApiModel({ packageName: "@scope/pkg", entryName: "utils" });
+
+			const perEntryModels = new Map([
+				["index", mainModel],
+				["utils", utilsModel],
+			]);
+
+			const result = mergeApiModels({
+				perEntryModels,
+				packageName: "@scope/pkg",
+				exportPaths: { index: ".", utils: "./utils" },
+			});
+
+			expect(result.kind).toBe("Package");
+			const entryPoints = result.members as Record<string, unknown>[];
+			expect(entryPoints).toHaveLength(2);
+
+			// Main entry first
+			expect(entryPoints[0].kind).toBe("EntryPoint");
+			expect(entryPoints[0].canonicalReference).toBe("@scope/pkg!");
+			expect(entryPoints[0].name).toBe("");
+
+			// Sub-entry second
+			expect(entryPoints[1].kind).toBe("EntryPoint");
+			expect(entryPoints[1].canonicalReference).toBe("@scope/pkg/utils!");
+			expect(entryPoints[1].name).toBe("utils");
+		});
+
+		it("should rewrite deep member canonical references for sub-entries", () => {
+			const utilsModel = makeApiModel({
+				packageName: "@scope/pkg",
+				entryName: "utils",
+				members: [
+					{
+						kind: "Function",
+						canonicalReference: "@scope/pkg!helperFn:function(1)",
+						name: "helperFn",
+					},
+					{
+						kind: "Interface",
+						canonicalReference: "@scope/pkg!MyInterface:interface",
+						name: "MyInterface",
+						members: [
+							{
+								kind: "PropertySignature",
+								canonicalReference: "@scope/pkg!MyInterface#prop:member",
+								name: "prop",
+							},
+						],
+					},
+				],
+			});
+
+			const perEntryModels = new Map([["utils", utilsModel]]);
+
+			const result = mergeApiModels({
+				perEntryModels,
+				packageName: "@scope/pkg",
+				exportPaths: { utils: "./utils" },
+			});
+
+			const entryPoints = result.members as Record<string, unknown>[];
+			expect(entryPoints).toHaveLength(1);
+
+			const ep = entryPoints[0];
+			expect(ep.canonicalReference).toBe("@scope/pkg/utils!");
+			expect(ep.name).toBe("utils");
+
+			// Check deep member canonical references are rewritten
+			const epMembers = ep.members as Record<string, unknown>[];
+			expect(epMembers[0].canonicalReference).toBe("@scope/pkg/utils!helperFn:function(1)");
+			expect(epMembers[1].canonicalReference).toBe("@scope/pkg/utils!MyInterface:interface");
+
+			// Check nested members
+			const interfaceMembers = (epMembers[1] as Record<string, unknown>).members as Record<string, unknown>[];
+			expect(interfaceMembers[0].canonicalReference).toBe("@scope/pkg/utils!MyInterface#prop:member");
+		});
+
+		it("should handle nested export paths", () => {
+			const nestedModel = makeApiModel({ packageName: "@scope/pkg", entryName: "nested-one" });
+
+			const perEntryModels = new Map([["nested-one", nestedModel]]);
+
+			const result = mergeApiModels({
+				perEntryModels,
+				packageName: "@scope/pkg",
+				exportPaths: { "nested-one": "./nested/one" },
+			});
+
+			const entryPoints = result.members as Record<string, unknown>[];
+			expect(entryPoints[0].canonicalReference).toBe("@scope/pkg/nested/one!");
+			expect(entryPoints[0].name).toBe("nested/one");
+		});
+
+		it("should throw when given zero models", () => {
+			expect(() =>
+				mergeApiModels({
+					perEntryModels: new Map(),
+					packageName: "@scope/pkg",
+					exportPaths: {},
+				}),
+			).toThrow("Cannot merge zero API models");
+		});
+
+		it("should keep main entry first when entries are in different order", () => {
+			const utilsModel = makeApiModel({ packageName: "@scope/pkg", entryName: "utils" });
+			const mainModel = makeApiModel({ packageName: "@scope/pkg", entryName: "index" });
+
+			// utils before index in iteration order
+			const perEntryModels = new Map([
+				["utils", utilsModel],
+				["index", mainModel],
+			]);
+
+			const result = mergeApiModels({
+				perEntryModels,
+				packageName: "@scope/pkg",
+				exportPaths: { index: ".", utils: "./utils" },
+			});
+
+			const entryPoints = result.members as Record<string, unknown>[];
+
+			// Main entry should be first regardless of Map insertion order
+			expect(entryPoints[0].canonicalReference).toBe("@scope/pkg!");
+			expect(entryPoints[0].name).toBe("");
+			expect(entryPoints[1].canonicalReference).toBe("@scope/pkg/utils!");
 		});
 	});
 });

--- a/src/rslib/plugins/dts-plugin.ts
+++ b/src/rslib/plugins/dts-plugin.ts
@@ -458,7 +458,7 @@ export class TsDocConfigBuilder {
 		const tsdocConfig: Record<string, unknown> = {
 			$schema: "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
 			noStandardTags: !useStandardTags,
-			reportUnsupportedHtmlElements: false,
+			reportUnsupportedHtmlElements: true,
 		};
 
 		// Only include tagDefinitions if there are any (custom tags or subset of groups)
@@ -586,10 +586,9 @@ export class TsDocConfigBuilder {
  * API model generation is enabled by default. To disable, set `apiModel: false`.
  * Providing an options object implicitly enables API model generation.
  *
- * API models are only generated for the main "index" entry point (the "." export).
- * Additional entry points like "./hooks" or "./utils" do not generate separate API models.
- * This prevents multiple conflicting API models and ensures a single source of truth
- * for package documentation.
+ * When a package has multiple entry points, API Extractor runs for each entry and the
+ * resulting per-entry models are merged into a single API model with multiple
+ * EntryPoint members. Canonical references are scoped per entry point.
  *
  * @public
  */
@@ -859,12 +858,21 @@ export async function collectDtsFiles(
 interface BundleDtsResult {
 	/** Map of entry names to their bundled file paths in temp */
 	bundledFiles: Map<string, string>;
-	/** Path to the generated API model file (if apiModel was enabled) */
-	apiModelPath?: string;
+	/** Map of entry names to their generated API model file paths (if apiModel was enabled) */
+	apiModelPaths: Map<string, string>;
 	/** Path to the generated tsdoc-metadata.json file (if enabled) */
 	tsdocMetadataPath?: string;
 	/** Path to the persisted tsdoc.json file (if persistConfig was enabled) */
 	tsdocConfigPath?: string;
+}
+
+/**
+ * Resolves the tsdoc-metadata.json filename from API model options.
+ * @internal
+ */
+function resolveTsdocMetadataFilename(apiModel: ApiModelOptions | boolean | undefined): string {
+	const option = typeof apiModel === "object" ? apiModel.tsdocMetadata : undefined;
+	return typeof option === "object" && option.filename ? option.filename : "tsdoc-metadata.json";
 }
 
 /**
@@ -889,13 +897,11 @@ async function bundleDtsFiles(options: {
 		options;
 
 	const bundledFiles = new Map<string, string>();
-	let apiModelPath: string | undefined;
+	const apiModelPaths = new Map<string, string>();
 	let tsdocMetadataPath: string | undefined;
 
 	// apiModel is enabled when it's true or an object (any object implicitly enables)
 	const apiModelEnabled = apiModel === true || typeof apiModel === "object";
-	// Temp filename for internal use - final output filename is determined at emission time
-	const apiModelFilename = typeof apiModel === "object" && apiModel.filename ? apiModel.filename : "api.json";
 
 	// TSDoc options from apiModel
 	const tsdocOptions = typeof apiModel === "object" ? apiModel.tsdoc : undefined;
@@ -913,10 +919,7 @@ async function bundleDtsFiles(options: {
 		(tsdocMetadataOption === undefined ||
 			tsdocMetadataOption === true ||
 			(typeof tsdocMetadataOption === "object" && tsdocMetadataOption.enabled !== false));
-	const tsdocMetadataFilename =
-		typeof tsdocMetadataOption === "object" && tsdocMetadataOption.filename
-			? tsdocMetadataOption.filename
-			: "tsdoc-metadata.json";
+	const tsdocMetadataFilename = resolveTsdocMetadataFilename(apiModel);
 
 	// Validate that API Extractor is installed before attempting import
 	getApiExtractorPath();
@@ -979,12 +982,13 @@ async function bundleDtsFiles(options: {
 		const outputFileName = `${entryName}.d.ts`;
 		const tempBundledPath = join(tempOutputDir, outputFileName);
 
-		// Only generate API model for the main "index" entry
-		const generateApiModel = apiModelEnabled && entryName === "index";
-		const tempApiModelPath = generateApiModel ? join(tempOutputDir, apiModelFilename) : undefined;
+		// Generate API model for ALL entries when apiModel is enabled
+		const isMainEntry = entryName === "index" || entryPoints.size === 1;
+		const generateApiModel = apiModelEnabled;
+		const tempApiModelPath = generateApiModel ? join(tempOutputDir, `${entryName}.api.json`) : undefined;
 
-		// Only generate tsdocMetadata for the main "index" entry (alongside API model)
-		const generateTsdocMetadata = tsdocMetadataEnabled && entryName === "index";
+		// Generate tsdocMetadata only for the main entry
+		const generateTsdocMetadata = tsdocMetadataEnabled && isMainEntry;
 		const tempTsdocMetadataPath = generateTsdocMetadata ? join(tempOutputDir, tsdocMetadataFilename) : undefined;
 
 		// Create API Extractor configuration
@@ -1013,7 +1017,7 @@ async function bundleDtsFiles(options: {
 						...(tempTsdocMetadataPath && { tsdocMetadataFilePath: tempTsdocMetadataPath }),
 					},
 				}),
-				bundledPackages: bundledPackages,
+				bundledPackages,
 			},
 			packageJsonFullPath: join(cwd, "package.json"),
 			configObjectFullPath: undefined,
@@ -1142,7 +1146,7 @@ async function bundleDtsFiles(options: {
 
 		// Store the API model path if generated
 		if (generateApiModel && tempApiModelPath) {
-			apiModelPath = tempApiModelPath;
+			apiModelPaths.set(entryName, tempApiModelPath);
 		}
 
 		// Store the tsdoc-metadata.json path if generated
@@ -1164,7 +1168,7 @@ async function bundleDtsFiles(options: {
 
 	return {
 		bundledFiles,
-		...(apiModelPath && { apiModelPath }),
+		apiModelPaths,
 		...(tsdocMetadataPath && { tsdocMetadataPath }),
 		...(tsdocConfigPath && { tsdocConfigPath }),
 	};
@@ -1183,6 +1187,110 @@ async function bundleDtsFiles(options: {
  */
 export function stripSourceMapComment(content: string): string {
 	return content.replace(/\/\/# sourceMappingURL=\S+\.d\.ts\.map\s*$/gm, "").trim();
+}
+
+/**
+ * Merges per-entry API models into a single Package with multiple EntryPoint members.
+ *
+ * @remarks
+ * Each per-entry API model is a Package (root object with `kind: "Package"`)
+ * whose `members` array contains a single EntryPoint. This function extracts
+ * the EntryPoints, rewrites canonical references for sub-entries, and combines
+ * them into a single Package with all EntryPoints.
+ *
+ * @param options - Merge options
+ * @returns Merged API model with multiple EntryPoint members
+ *
+ * @internal
+ */
+export function mergeApiModels(options: {
+	perEntryModels: Map<string, Record<string, unknown>>;
+	packageName: string;
+	exportPaths: Record<string, string>;
+}): Record<string, unknown> {
+	const { perEntryModels, packageName, exportPaths } = options;
+
+	if (perEntryModels.size === 0) {
+		throw new Error("Cannot merge zero API models");
+	}
+
+	// Use metadata from the first model (all identical — same package, same config)
+	const firstModel = perEntryModels.values().next().value as Record<string, unknown>;
+
+	// Deep clone the first model to use as the base
+	// The root object IS the Package (kind: "Package", members: [EntryPoint])
+	const merged = JSON.parse(JSON.stringify(firstModel)) as Record<string, unknown>;
+
+	// Collect all EntryPoint members from each per-entry model
+	const entryPointMembers: unknown[] = [];
+
+	for (const [entryName, model] of perEntryModels) {
+		// The root is the Package; its members are EntryPoints
+		const entryPoints = model.members as unknown[];
+		if (!entryPoints || entryPoints.length === 0) continue;
+
+		// Each per-entry model has one EntryPoint in Package.members
+		const entryPoint = JSON.parse(JSON.stringify(entryPoints[0])) as Record<string, unknown>;
+
+		// Determine the export path for this entry
+		const exportPath = exportPaths[entryName] ?? (entryName === "index" ? "." : `./${entryName}`);
+		const isMainEntry = exportPath === ".";
+
+		if (isMainEntry) {
+			// Main entry: keep canonical reference as @scope/package!, name ""
+			entryPointMembers.unshift(entryPoint);
+		} else {
+			// Sub-entry: rewrite canonical reference to @scope/package/subpath!
+			const subpath = exportPath.replace(/^\.\//, "");
+			const originalPrefix = `${packageName}!`;
+			const newPrefix = `${packageName}/${subpath}!`;
+
+			entryPoint.canonicalReference = newPrefix;
+			entryPoint.name = subpath;
+
+			// Rewrite all canonical references within the entry point's member tree
+			rewriteCanonicalReferences(entryPoint, originalPrefix, newPrefix);
+
+			entryPointMembers.push(entryPoint);
+		}
+	}
+
+	// Replace the Package's members with all EntryPoints
+	merged.members = entryPointMembers;
+
+	return merged;
+}
+
+/**
+ * Recursively rewrites canonical reference strings within an API model member tree.
+ * @internal
+ */
+function rewriteCanonicalReferences(node: unknown, originalPrefix: string, newPrefix: string): void {
+	if (!node || typeof node !== "object") return;
+
+	if (Array.isArray(node)) {
+		for (const item of node) {
+			rewriteCanonicalReferences(item, originalPrefix, newPrefix);
+		}
+		return;
+	}
+
+	const obj = node as Record<string, unknown>;
+
+	// Rewrite canonicalReference on members (but not on the EntryPoint itself — already handled)
+	if (typeof obj.canonicalReference === "string" && obj.kind !== "EntryPoint") {
+		const ref = obj.canonicalReference as string;
+		if (ref.startsWith(originalPrefix)) {
+			obj.canonicalReference = ref.replace(originalPrefix, newPrefix);
+		}
+	}
+
+	// Recurse into members array
+	if (Array.isArray(obj.members)) {
+		for (const member of obj.members) {
+			rewriteCanonicalReferences(member, originalPrefix, newPrefix);
+		}
+	}
 }
 
 /**
@@ -1523,8 +1631,60 @@ export const DtsPlugin = (options: DtsPluginOptions = {}): RsbuildPlugin => {
 							return;
 						}
 
-						// Check if we should bundle declarations with API Extractor
-						if (options.bundle) {
+						// Emit individual .d.ts files when not bundling
+						if (!options.bundle) {
+							let emittedCount = 0;
+							for (const file of dtsFiles) {
+								// Skip .d.ts.map files - keep them only in temp directory for API Extractor
+								if (file.relativePath.endsWith(".d.ts.map")) {
+									continue;
+								}
+
+								// Determine output path relative to dist
+								// Strip 'src/' prefix if present since tsgo preserves source directory structure
+								let outputPath = file.relativePath;
+								if (outputPath.startsWith("src/")) {
+									outputPath = outputPath.slice(4); // Remove 'src/'
+								}
+
+								// Apply custom extension if specified and different from default
+								if (dtsExtension !== ".d.ts" && outputPath.endsWith(".d.ts")) {
+									outputPath = outputPath.replace(/\.d\.ts$/, dtsExtension);
+								}
+
+								// Only emit .d.ts for files that have a corresponding .js in the compilation
+								// tsgo generates declarations for all files in tsconfig scope, but we only
+								// want declarations for files that are in the JS compilation (import graph)
+								const jsOutputPath = outputPath.replace(/\.d\.(ts|mts|cts)$/, ".js");
+								if (!context.compilation.assets[jsOutputPath]) {
+									continue;
+								}
+
+								let content = await readFile(file.path, "utf-8");
+
+								// Strip sourceMappingURL comment before emitting to dist
+								content = stripSourceMapComment(content);
+
+								// Create source and emit asset
+								const source = new context.sources.OriginalSource(content, outputPath);
+								context.compilation.emitAsset(outputPath, source);
+								emittedCount++;
+
+								// Add .d.ts files to files array
+								if (filesArray && outputPath.endsWith(".d.ts")) {
+									filesArray.add(outputPath);
+								}
+							}
+
+							logger.info(
+								`${color.dim(`[${envId}]`)} Emitted ${emittedCount} declaration file${emittedCount === 1 ? "" : "s"} through asset pipeline`,
+							);
+						}
+
+						// Bundle declarations and/or generate API model
+						// Runs when: bundle mode (rollup per entry) or API model enabled (multi-entry merge)
+						const apiModelEnabled = options.apiModel === true || typeof options.apiModel === "object";
+						if (options.bundle || apiModelEnabled) {
 							try {
 								// Read package.json to discover entry points
 								// First check if api-report-plugin exposed a modified version
@@ -1541,9 +1701,8 @@ export const DtsPlugin = (options: DtsPluginOptions = {}): RsbuildPlugin => {
 									packageJson = exposedPackageJson;
 								}
 
-								// Extract ALL TypeScript exports using EntryExtractor (skip bin entries)
-								const extractor = new EntryExtractor();
-								const { entries } = extractor.extract(packageJson);
+								// Extract ALL TypeScript exports (skip bin entries)
+								const { entries, exportPaths } = new EntryExtractor().extract(packageJson);
 								const entryPoints = new Map<string, string>();
 
 								// Get virtual entry names to skip type generation for them
@@ -1596,7 +1755,7 @@ export const DtsPlugin = (options: DtsPluginOptions = {}): RsbuildPlugin => {
 									await mkdir(tempBundledDir, { recursive: true });
 
 									// Bundle declarations using API Extractor (writes to temp directory)
-									const { bundledFiles, apiModelPath, tsdocMetadataPath, tsdocConfigPath } = await bundleDtsFiles({
+									const { bundledFiles, apiModelPaths, tsdocMetadataPath, tsdocConfigPath } = await bundleDtsFiles({
 										cwd,
 										tempDtsDir,
 										tempOutputDir: tempBundledDir,
@@ -1608,29 +1767,54 @@ export const DtsPlugin = (options: DtsPluginOptions = {}): RsbuildPlugin => {
 										...(options.apiModel !== undefined && { apiModel: options.apiModel }),
 									});
 
-									// Emit bundled .d.ts files from temp directory through asset pipeline
-									let emittedCount = 0;
-									for (const [entryName, tempBundledPath] of bundledFiles) {
-										// Determine final output file name
-										// Always use flat structure: index.d.ts, hooks.d.ts, foo/bar.d.ts
-										const bundledFileName = `${entryName}.d.ts`;
-
-										// Read from temp and strip sourceMappingURL comment before emitting
-										let content = await readFile(tempBundledPath, "utf-8");
-										content = stripSourceMapComment(content);
-										const source = new context.sources.OriginalSource(content, bundledFileName);
-										context.compilation.emitAsset(bundledFileName, source);
-										emittedCount++;
-
-										// Add .d.ts file to files array (but not .d.ts.map files)
-										if (filesArray) {
-											filesArray.add(bundledFileName);
+									// Merge per-entry API models if multiple entries generated models
+									let apiModelPath: string | undefined;
+									if (apiModelPaths.size === 1) {
+										// Single entry — use as-is
+										apiModelPath = apiModelPaths.values().next().value as string;
+									} else if (apiModelPaths.size > 1 && packageJson.name) {
+										// Multiple entries — merge into one Package with multiple EntryPoints
+										logger.info(`${color.dim(`[${envId}]`)} Merging API models from ${apiModelPaths.size} entries...`);
+										const perEntryModels = new Map<string, Record<string, unknown>>();
+										for (const [entryName, modelPath] of apiModelPaths) {
+											const content = await readFile(modelPath, "utf-8");
+											perEntryModels.set(entryName, JSON.parse(content));
 										}
+										const mergedModel = mergeApiModels({
+											perEntryModels,
+											packageName: packageJson.name,
+											exportPaths,
+										});
+										const mergedPath = join(tempBundledDir, "merged.api.json");
+										await writeFile(mergedPath, JSON.stringify(mergedModel, null, 2), "utf-8");
+										apiModelPath = mergedPath;
 									}
 
-									logger.info(
-										`${color.dim(`[${envId}]`)} Emitted ${emittedCount} bundled declaration file${emittedCount === 1 ? "" : "s"} through asset pipeline`,
-									);
+									// Emit bundled .d.ts files only in bundle mode (not in virtual-barrel-only mode)
+									if (options.bundle) {
+										let emittedCount = 0;
+										for (const [entryName, tempBundledPath] of bundledFiles) {
+											// Determine final output file name
+											// Always use flat structure: index.d.ts, hooks.d.ts, foo/bar.d.ts
+											const bundledFileName = `${entryName}.d.ts`;
+
+											// Read from temp and strip sourceMappingURL comment before emitting
+											let content = await readFile(tempBundledPath, "utf-8");
+											content = stripSourceMapComment(content);
+											const source = new context.sources.OriginalSource(content, bundledFileName);
+											context.compilation.emitAsset(bundledFileName, source);
+											emittedCount++;
+
+											// Add .d.ts file to files array (but not .d.ts.map files)
+											if (filesArray) {
+												filesArray.add(bundledFileName);
+											}
+										}
+
+										logger.info(
+											`${color.dim(`[${envId}]`)} Emitted ${emittedCount} bundled declaration file${emittedCount === 1 ? "" : "s"} through asset pipeline`,
+										);
+									}
 
 									// Emit API model file if generated
 									if (apiModelPath) {
@@ -1659,15 +1843,9 @@ export const DtsPlugin = (options: DtsPluginOptions = {}): RsbuildPlugin => {
 										// Expose data needed for localPaths copying in onCloseBuild
 										// (files are read from dist after build completes, ensuring transformed package.json)
 										const localPaths = typeof options.apiModel === "object" ? options.apiModel.localPaths : undefined;
-										const isCI = process.env.GITHUB_ACTIONS === "true" || process.env.CI === "true";
 
-										if (localPaths && localPaths.length > 0 && !isCI) {
-											const tsdocMetadataOption =
-												typeof options.apiModel === "object" ? options.apiModel.tsdocMetadata : undefined;
-											const localTsdocFilename =
-												typeof tsdocMetadataOption === "object" && tsdocMetadataOption.filename
-													? tsdocMetadataOption.filename
-													: "tsdoc-metadata.json";
+										if (localPaths && localPaths.length > 0 && !TsDocConfigBuilder.isCI()) {
+											const localTsdocFilename = resolveTsdocMetadataFilename(options.apiModel);
 
 											api.expose("dts-local-paths-data", {
 												localPaths,
@@ -1683,12 +1861,7 @@ export const DtsPlugin = (options: DtsPluginOptions = {}): RsbuildPlugin => {
 
 									// Emit tsdoc-metadata.json file if generated
 									if (tsdocMetadataPath) {
-										const tsdocMetadataOption =
-											typeof options.apiModel === "object" ? options.apiModel.tsdocMetadata : undefined;
-										const tsdocMetadataFilename =
-											typeof tsdocMetadataOption === "object" && tsdocMetadataOption.filename
-												? tsdocMetadataOption.filename
-												: "tsdoc-metadata.json";
+										const tsdocMetadataFilename = resolveTsdocMetadataFilename(options.apiModel);
 										const tsdocMetadataContent = (await readFile(tsdocMetadataPath, "utf-8")).replaceAll("\r\n", "\n");
 										const tsdocMetadataSource = new context.sources.OriginalSource(
 											tsdocMetadataContent,
@@ -1740,31 +1913,31 @@ export const DtsPlugin = (options: DtsPluginOptions = {}): RsbuildPlugin => {
 
 									// Remove .d.ts.map files that Rspack auto-generates for our emitted .d.ts assets
 									// We keep .d.ts.map files in the declarations directory for API Extractor, but dont want them in dist
-									for (const [entryName] of bundledFiles) {
-										const bundledFileName = `${entryName}.d.ts`;
-										const mapFileName = `${bundledFileName}.map`;
+									if (options.bundle) {
+										for (const [entryName] of bundledFiles) {
+											const bundledFileName = `${entryName}.d.ts`;
+											const mapFileName = `${bundledFileName}.map`;
 
-										// Remove .d.ts.map files that Rspack auto-generates for our emitted .d.ts assets
-										// We keep .d.ts.map files in the declarations directory for API Extractor, but dont want them in dist
-										for (const file of dtsFiles) {
-											if (file.relativePath.endsWith(".d.ts.map")) {
-												continue;
+											for (const file of dtsFiles) {
+												if (file.relativePath.endsWith(".d.ts.map")) {
+													continue;
+												}
+												let outputPath = file.relativePath;
+												if (outputPath.startsWith("src/")) {
+													outputPath = outputPath.slice(4);
+												}
+												if (dtsExtension !== ".d.ts" && outputPath.endsWith(".d.ts")) {
+													outputPath = outputPath.replace(/\.d\.ts$/, dtsExtension);
+												}
+												const mapFileName = `${outputPath}.map`;
+												if (context.compilation.assets[mapFileName]) {
+													delete context.compilation.assets[mapFileName];
+												}
 											}
-											let outputPath = file.relativePath;
-											if (outputPath.startsWith("src/")) {
-												outputPath = outputPath.slice(4);
-											}
-											if (dtsExtension !== ".d.ts" && outputPath.endsWith(".d.ts")) {
-												outputPath = outputPath.replace(/\.d\.ts$/, dtsExtension);
-											}
-											const mapFileName = `${outputPath}.map`;
+
 											if (context.compilation.assets[mapFileName]) {
 												delete context.compilation.assets[mapFileName];
 											}
-										}
-
-										if (context.compilation.assets[mapFileName]) {
-											delete context.compilation.assets[mapFileName];
 										}
 									}
 								}
@@ -1774,46 +1947,6 @@ export const DtsPlugin = (options: DtsPluginOptions = {}): RsbuildPlugin => {
 									throw error;
 								}
 							}
-						} else {
-							// Emit each file individually through the asset pipeline
-							let emittedCount = 0;
-							for (const file of dtsFiles) {
-								// Skip .d.ts.map files - keep them only in temp directory for API Extractor
-								if (file.relativePath.endsWith(".d.ts.map")) {
-									continue;
-								}
-
-								let content = await readFile(file.path, "utf-8");
-
-								// Determine output path relative to dist
-								// Strip 'src/' prefix if present since tsgo preserves source directory structure
-								let outputPath = file.relativePath;
-								if (outputPath.startsWith("src/")) {
-									outputPath = outputPath.slice(4); // Remove 'src/'
-								}
-
-								// Apply custom extension if specified and different from default
-								if (dtsExtension !== ".d.ts" && outputPath.endsWith(".d.ts")) {
-									outputPath = outputPath.replace(/\.d\.ts$/, dtsExtension);
-								}
-
-								// Strip sourceMappingURL comment before emitting to dist
-								content = stripSourceMapComment(content);
-
-								// Create source and emit asset
-								const source = new context.sources.OriginalSource(content, outputPath);
-								context.compilation.emitAsset(outputPath, source);
-								emittedCount++;
-
-								// Add .d.ts files to files array
-								if (filesArray && outputPath.endsWith(".d.ts")) {
-									filesArray.add(outputPath);
-								}
-							}
-
-							logger.info(
-								`${color.dim(`[${envId}]`)} Emitted ${emittedCount} declaration file${emittedCount === 1 ? "" : "s"} through asset pipeline`,
-							);
 						}
 					} catch (error) {
 						log.global.error("Failed to generate declaration files:", error);

--- a/src/rslib/plugins/tsdoc-lint-plugin.ts
+++ b/src/rslib/plugins/tsdoc-lint-plugin.ts
@@ -1,16 +1,16 @@
 import type { PathLike } from "node:fs";
-import { dirname, join, relative } from "node:path";
+import { readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
 import type { RsbuildPlugin, RsbuildPluginAPI } from "@rsbuild/core";
 import { logger } from "@rsbuild/core";
 import type { ESLint as ESLintNamespace, Linter } from "eslint";
 import color from "picocolors";
+import type { PackageJson } from "../../types/package-json.js";
 import type { TsDocLintErrorBehavior, TsDocOptions } from "./dts-plugin.js";
 import { TsDocConfigBuilder } from "./dts-plugin.js";
+import { EntryExtractor } from "./utils/entry-extractor.js";
 import type { ImportGraphError } from "./utils/import-graph.js";
 import { ImportGraph } from "./utils/import-graph.js";
-
-// Re-export for backwards compatibility
-export type { TsDocLintErrorBehavior } from "./dts-plugin.js";
 
 /**
  * Helper interface for handling ESM/CJS module format differences.
@@ -124,6 +124,17 @@ export interface TsDocLintPluginOptions {
 	 * @defaultValue `true`
 	 */
 	persistConfig?: boolean | PathLike;
+
+	/**
+	 * Whether to run lint per entry point individually with per-entry logging.
+	 *
+	 * @remarks
+	 * When enabled, each entry point is linted separately and results are
+	 * logged per entry for better visibility in bundleless mode.
+	 *
+	 * @defaultValue false
+	 */
+	perEntry?: boolean;
 }
 
 /**
@@ -256,6 +267,54 @@ export function discoverFilesToLint(options: TsDocLintPluginOptions, cwd: string
 		isGlobPattern: false,
 	};
 }
+
+/**
+ * Discovers files to lint per entry point using import graph analysis.
+ *
+ * @param cwd - The project root directory
+ * @returns Map of entry name to discovery result, plus aggregated errors
+ *
+ * @internal
+ */
+/* v8 ignore start -- Integration function using ImportGraph and fs */
+export function discoverFilesToLintPerEntry(cwd: string): {
+	perEntry: Map<string, FileDiscoveryResult>;
+	errors: ImportGraphError[];
+} {
+	const packageJsonPath = join(cwd, "package.json");
+	let packageJson: PackageJson;
+	try {
+		packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as PackageJson;
+	} catch {
+		return { perEntry: new Map(), errors: [] };
+	}
+
+	const { entries } = new EntryExtractor().extract(packageJson);
+
+	const graph = new ImportGraph({ rootDir: cwd });
+	const perEntry = new Map<string, FileDiscoveryResult>();
+	const allErrors: ImportGraphError[] = [];
+
+	for (const [entryName, sourcePath] of Object.entries(entries)) {
+		// Skip bin entries
+		if (entryName.startsWith("bin/")) continue;
+
+		const resolvedPath = sourcePath.startsWith(".") ? resolve(cwd, sourcePath) : sourcePath;
+
+		const result = graph.traceFromEntries([resolvedPath]);
+
+		perEntry.set(entryName, {
+			files: result.files,
+			errors: result.errors,
+			isGlobPattern: false,
+		});
+
+		allErrors.push(...result.errors);
+	}
+
+	return { perEntry, errors: allErrors };
+}
+/* v8 ignore stop */
 
 /**
  * Result of running TSDoc lint via ESLint.
@@ -411,6 +470,136 @@ export async function runTsDocLint(options: TsDocLintPluginOptions, cwd: string)
 }
 
 /**
+ * Runs TSDoc lint per entry point, providing per-entry logging visibility.
+ *
+ * @param options - Plugin options for configuring TSDoc linting
+ * @param cwd - The project root directory
+ * @returns Promise resolving to aggregated lint results and configuration paths
+ *
+ * @internal
+ */
+/* v8 ignore start -- Integration function using ESLint programmatically */
+export async function runTsDocLintPerEntry(options: TsDocLintPluginOptions, cwd: string): Promise<TsDocLintRunResult> {
+	// Generate tsdoc.json config file
+	const tsdocOptions = options.tsdoc ?? {};
+	const persistConfig = options.persistConfig;
+	const shouldPersist = TsDocConfigBuilder.shouldPersist(persistConfig);
+	const tsdocConfigOutputPath = TsDocConfigBuilder.getConfigPath(persistConfig, cwd);
+
+	const skipCIValidation = persistConfig === false;
+	const tsdocConfigPath = await TsDocConfigBuilder.writeConfigFile(
+		tsdocOptions,
+		dirname(tsdocConfigOutputPath),
+		skipCIValidation,
+	);
+
+	// Dynamic import ESLint and plugins
+	const eslintModule = await import("eslint");
+	const tsParserModule = await import("@typescript-eslint/parser");
+	const tsdocPluginModule = await import("eslint-plugin-tsdoc");
+
+	const { ESLint } = eslintModule;
+
+	const tsParser = (tsParserModule as ESModuleExport<Linter.Parser>).default ?? (tsParserModule as Linter.Parser);
+	const tsdocPlugin =
+		(tsdocPluginModule as ESModuleExport<ESLintNamespace.Plugin>).default ??
+		(tsdocPluginModule as ESLintNamespace.Plugin);
+
+	// Discover files per entry
+	const { perEntry, errors: allErrors } = discoverFilesToLintPerEntry(cwd);
+
+	if (perEntry.size === 0) {
+		return {
+			results: { errorCount: 0, warningCount: 0, messages: [] },
+			...(shouldPersist && { tsdocConfigPath }),
+			...(allErrors.length > 0 && { discoveryErrors: allErrors }),
+		};
+	}
+
+	// Create ESLint instance (shared across entries)
+	const eslint = new ESLint({
+		cwd,
+		overrideConfigFile: true,
+		overrideConfig: [
+			{
+				ignores: ["**/node_modules/**", "**/dist/**", "**/coverage/**"],
+			},
+			{
+				files: ["**/*.ts", "**/*.tsx"],
+				languageOptions: {
+					parser: tsParser as Linter.Parser,
+				},
+				plugins: { tsdoc: tsdocPlugin as ESLintNamespace.Plugin },
+				rules: {
+					"tsdoc/syntax": "error",
+				},
+			},
+		],
+	});
+
+	// Aggregated results
+	const allMessages: LintMessage[] = [];
+	let totalErrors = 0;
+	let totalWarnings = 0;
+
+	// Lint per entry
+	for (const [entryName, discovery] of perEntry) {
+		if (discovery.files.length === 0) {
+			continue;
+		}
+
+		const exportKey = entryName === "index" ? "." : `./${entryName}`;
+		logger.info(
+			`${color.dim("[tsdoc-lint]")} Validating "${exportKey}" (${discovery.files.length} file${discovery.files.length === 1 ? "" : "s"})...`,
+		);
+
+		const eslintResults = await eslint.lintFiles(discovery.files);
+
+		let entryErrors = 0;
+		let entryWarnings = 0;
+
+		for (const result of eslintResults) {
+			for (const msg of result.messages) {
+				allMessages.push({
+					filePath: result.filePath,
+					line: msg.line,
+					column: msg.column,
+					message: msg.message,
+					ruleId: msg.ruleId,
+					severity: msg.severity as 1 | 2,
+				});
+
+				if (msg.severity === 2) {
+					entryErrors++;
+					totalErrors++;
+				} else {
+					entryWarnings++;
+					totalWarnings++;
+				}
+			}
+		}
+
+		if (entryErrors === 0 && entryWarnings === 0) {
+			logger.info(`${color.dim("[tsdoc-lint]")} ${color.green(`\u2713 "${exportKey}" - All TSDoc comments valid`)}`);
+		} else {
+			const errorText = entryErrors === 1 ? "error" : "errors";
+			const warningText = entryWarnings === 1 ? "warning" : "warnings";
+			const parts: string[] = [];
+			if (entryErrors > 0) parts.push(`${entryErrors} ${errorText}`);
+			if (entryWarnings > 0) parts.push(`${entryWarnings} ${warningText}`);
+			logger.warn(`${color.dim("[tsdoc-lint]")} ${color.red(`\u2717 "${exportKey}" - ${parts.join(", ")} found`)}`);
+		}
+	}
+
+	return {
+		results: { errorCount: totalErrors, warningCount: totalWarnings, messages: allMessages },
+		...(shouldPersist && { tsdocConfigPath }),
+		...(allErrors.length > 0 && { discoveryErrors: allErrors }),
+	};
+}
+/* v8 ignore stop */
+
+/**
  * Cleans up the tsdoc.json config file.
  *
  * @param configPath - Path to the config file to delete
@@ -503,7 +692,9 @@ export const TsDocLintPlugin = (options: TsDocLintPluginOptions = {}): RsbuildPl
 				logger.info(`${color.dim("[tsdoc-lint]")} Validating TSDoc comments...`);
 
 				try {
-					const { results, tsdocConfigPath, discoveryErrors } = await runTsDocLint(options, cwd);
+					const { results, tsdocConfigPath, discoveryErrors } = options.perEntry
+						? await runTsDocLintPerEntry(options, cwd)
+						: await runTsDocLint(options, cwd);
 
 					// Log any discovery warnings
 					if (discoveryErrors && discoveryErrors.length > 0) {

--- a/src/rslib/plugins/utils/entry-extractor.test.ts
+++ b/src/rslib/plugins/utils/entry-extractor.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { PackageJson } from "../../../types/package-json.js";
-import { EntryExtractor, extractEntriesFromPackageJson } from "./entry-extractor.js";
+import { EntryExtractor } from "./entry-extractor.js";
 
-describe("extractEntriesFromPackageJson", () => {
+describe("EntryExtractor.extract", () => {
 	it("should extract entries from exports field with string export", () => {
 		const packageJson: PackageJson = {
 			name: "test-package",
@@ -10,10 +10,13 @@ describe("extractEntriesFromPackageJson", () => {
 			exports: "./src/index.ts",
 		};
 
-		const { entries } = extractEntriesFromPackageJson(packageJson);
+		const { entries, exportPaths } = new EntryExtractor().extract(packageJson);
 
 		expect(entries).toEqual({
 			index: "./src/index.ts",
+		});
+		expect(exportPaths).toEqual({
+			index: ".",
 		});
 	});
 
@@ -28,11 +31,15 @@ describe("extractEntriesFromPackageJson", () => {
 			},
 		};
 
-		const { entries } = extractEntriesFromPackageJson(packageJson);
+		const { entries, exportPaths } = new EntryExtractor().extract(packageJson);
 
 		expect(entries).toEqual({
 			index: "./src/index.ts",
 			utils: "./src/utils.ts",
+		});
+		expect(exportPaths).toEqual({
+			index: ".",
+			utils: "./utils",
 		});
 	});
 
@@ -53,11 +60,15 @@ describe("extractEntriesFromPackageJson", () => {
 			},
 		};
 
-		const { entries } = extractEntriesFromPackageJson(packageJson);
+		const { entries, exportPaths } = new EntryExtractor().extract(packageJson);
 
 		expect(entries).toEqual({
 			index: "./src/index.ts", // from import field
 			utils: "./src/utils.ts", // from import field
+		});
+		expect(exportPaths).toEqual({
+			index: ".",
+			utils: "./utils",
 		});
 	});
 
@@ -68,11 +79,13 @@ describe("extractEntriesFromPackageJson", () => {
 			bin: "./src/cli.ts",
 		};
 
-		const { entries } = extractEntriesFromPackageJson(packageJson);
+		const { entries, exportPaths } = new EntryExtractor().extract(packageJson);
 
 		expect(entries).toEqual({
 			"bin/cli": "./src/cli.ts",
 		});
+		// Bin entries don't have export paths
+		expect(exportPaths).toEqual({});
 	});
 
 	it("should extract entries from bin field with object bin", () => {
@@ -85,7 +98,7 @@ describe("extractEntriesFromPackageJson", () => {
 			},
 		};
 
-		const { entries } = extractEntriesFromPackageJson(packageJson);
+		const { entries } = new EntryExtractor().extract(packageJson);
 
 		expect(entries).toEqual({
 			"bin/cli": "./src/cli.ts",
@@ -105,7 +118,7 @@ describe("extractEntriesFromPackageJson", () => {
 			bin: "./bin/cli.js", // Should be skipped (JS file not in dist)
 		};
 
-		const { entries } = extractEntriesFromPackageJson(packageJson);
+		const { entries } = new EntryExtractor().extract(packageJson);
 
 		expect(entries).toEqual({});
 	});
@@ -118,7 +131,7 @@ describe("extractEntriesFromPackageJson", () => {
 			bin: "./bin/cli.tsx",
 		};
 
-		const { entries } = extractEntriesFromPackageJson(packageJson);
+		const { entries } = new EntryExtractor().extract(packageJson);
 
 		expect(entries).toEqual({
 			index: "./src/component.tsx",
@@ -139,7 +152,7 @@ describe("extractEntriesFromPackageJson", () => {
 			},
 		};
 
-		const { entries } = extractEntriesFromPackageJson(packageJson);
+		const { entries } = new EntryExtractor().extract(packageJson);
 
 		expect(entries).toEqual({
 			utils: "./src/utils.ts",
@@ -160,7 +173,7 @@ describe("extractEntriesFromPackageJson", () => {
 			},
 		};
 
-		const { entries } = extractEntriesFromPackageJson(packageJson);
+		const { entries } = new EntryExtractor().extract(packageJson);
 
 		expect(entries).toEqual({
 			index: "./src/index.ts",
@@ -178,7 +191,7 @@ describe("extractEntriesFromPackageJson", () => {
 			},
 		};
 
-		const { entries } = extractEntriesFromPackageJson(packageJson);
+		const { entries } = new EntryExtractor().extract(packageJson);
 
 		expect(entries).toEqual({
 			index: "./src/index.ts",
@@ -195,7 +208,7 @@ describe("extractEntriesFromPackageJson", () => {
 			},
 		};
 
-		const { entries } = extractEntriesFromPackageJson(packageJson);
+		const { entries } = new EntryExtractor().extract(packageJson);
 
 		expect(entries).toEqual({
 			index: "./src/index.ts",
@@ -217,7 +230,7 @@ describe("extractEntriesFromPackageJson", () => {
 			},
 		};
 
-		const { entries } = extractEntriesFromPackageJson(packageJson);
+		const { entries } = new EntryExtractor().extract(packageJson);
 
 		expect(entries).toEqual({
 			index: "./src/index.ts",
@@ -238,7 +251,7 @@ describe("extractEntriesFromPackageJson", () => {
 			},
 		};
 
-		const result = extractEntriesFromPackageJson(packageJson);
+		const result = new EntryExtractor().extract(packageJson);
 
 		expect(result.entries).toEqual({});
 	});
@@ -252,7 +265,7 @@ describe("extractEntriesFromPackageJson", () => {
 			},
 		};
 
-		const result = extractEntriesFromPackageJson(packageJson);
+		const result = new EntryExtractor().extract(packageJson);
 
 		expect(result.entries).toEqual({});
 	});
@@ -266,7 +279,7 @@ describe("extractEntriesFromPackageJson", () => {
 			},
 		};
 
-		const result = extractEntriesFromPackageJson(packageJson);
+		const result = new EntryExtractor().extract(packageJson);
 
 		expect(result.entries).toEqual({
 			utils: "./src/utils.ts",
@@ -286,7 +299,7 @@ describe("extractEntriesFromPackageJson", () => {
 			},
 		};
 
-		const result = extractEntriesFromPackageJson(packageJson);
+		const result = new EntryExtractor().extract(packageJson);
 
 		expect(result.entries).toEqual({
 			index: "./src/index.d.ts", // Should use types as fallback
@@ -305,7 +318,7 @@ describe("extractEntriesFromPackageJson", () => {
 			},
 		};
 
-		const result = extractEntriesFromPackageJson(packageJson);
+		const result = new EntryExtractor().extract(packageJson);
 
 		expect(result.entries).toEqual({
 			"bin/my-cli": "./src/cli.ts",
@@ -331,6 +344,10 @@ describe("EntryExtractor class", () => {
 			// Default behavior: path separators become hyphens
 			expect(result.entries).toEqual({
 				"utils-helpers": "./src/utils/helpers.ts",
+			});
+			// exportPaths maps entry name to original export key
+			expect(result.exportPaths).toEqual({
+				"utils-helpers": "./utils/helpers",
 			});
 		});
 
@@ -365,7 +382,9 @@ describe("EntryExtractor class", () => {
 			const result = extractor.extract(packageJson);
 
 			expect(result).toHaveProperty("entries");
+			expect(result).toHaveProperty("exportPaths");
 			expect(typeof result.entries).toBe("object");
+			expect(typeof result.exportPaths).toBe("object");
 		});
 
 		it("should handle empty package.json", () => {
@@ -378,6 +397,7 @@ describe("EntryExtractor class", () => {
 			const result = extractor.extract(packageJson);
 
 			expect(result.entries).toEqual({});
+			expect(result.exportPaths).toEqual({});
 		});
 
 		it("should extract from both exports and bin", () => {
@@ -442,45 +462,6 @@ describe("EntryExtractor class", () => {
 			expect(result.entries).toEqual({
 				"api-v1": "./src/api/v1.ts",
 				"utils-string-format": "./src/utils/string/format.ts",
-			});
-		});
-	});
-
-	describe("functional interface compatibility", () => {
-		it("should produce same results as class-based API", () => {
-			const packageJson: PackageJson = {
-				name: "test-package",
-				version: "1.0.0",
-				exports: {
-					".": "./src/index.ts",
-					"./utils": "./src/utils.ts",
-				},
-				bin: "./src/cli.ts",
-			};
-
-			const extractor = new EntryExtractor();
-			const classResult = extractor.extract(packageJson);
-			const funcResult = extractEntriesFromPackageJson(packageJson);
-
-			expect(classResult).toEqual(funcResult);
-		});
-
-		it("should pass options through functional interface", () => {
-			const packageJson: PackageJson = {
-				name: "test-package",
-				version: "1.0.0",
-				exports: {
-					"./deep/nested/path": "./src/deep/nested/path.ts",
-				},
-			};
-
-			const extractor = new EntryExtractor({ exportsAsIndexes: true });
-			const classResult = extractor.extract(packageJson);
-			const funcResult = extractEntriesFromPackageJson(packageJson, { exportsAsIndexes: true });
-
-			expect(classResult).toEqual(funcResult);
-			expect(classResult.entries).toEqual({
-				"deep/nested/path/index": "./src/deep/nested/path.ts",
 			});
 		});
 	});

--- a/src/rslib/plugins/utils/entry-extractor.ts
+++ b/src/rslib/plugins/utils/entry-extractor.ts
@@ -21,6 +21,13 @@ export interface ExtractedEntries {
 	 * Entry name to TypeScript source path mapping.
 	 */
 	entries: Record<string, string>;
+
+	/**
+	 * Entry name to original export key mapping.
+	 * Maps entry names back to the original package.json export path
+	 * (e.g., `"nested-one"` → `"./nested/one"`).
+	 */
+	exportPaths: Record<string, string>;
 }
 
 /**
@@ -83,22 +90,28 @@ export class EntryExtractor {
 	 */
 	extract(packageJson: PackageJson): ExtractedEntries {
 		const entries: Record<string, string> = {};
+		const exportPaths: Record<string, string> = {};
 
-		this.extractFromExports(packageJson.exports, entries);
+		this.extractFromExports(packageJson.exports, entries, exportPaths);
 		this.extractFromBin(packageJson.bin, entries);
 
-		return { entries };
+		return { entries, exportPaths };
 	}
 
 	/**
 	 * Extracts entries from the exports field.
 	 */
-	private extractFromExports(exports: PackageJson["exports"], entries: Record<string, string>): void {
+	private extractFromExports(
+		exports: PackageJson["exports"],
+		entries: Record<string, string>,
+		exportPaths: Record<string, string>,
+	): void {
 		if (!exports) return;
 
 		if (typeof exports === "string") {
 			if (this.isTypeScriptFile(exports)) {
 				entries.index = exports;
+				exportPaths.index = ".";
 			}
 			return;
 		}
@@ -119,6 +132,7 @@ export class EntryExtractor {
 
 			const entryName = this.createEntryName(key);
 			entries[entryName] = resolvedPath;
+			exportPaths[entryName] = key;
 		}
 	}
 
@@ -198,26 +212,4 @@ export class EntryExtractor {
 
 		return withoutPrefix.replace(/\//g, "-");
 	}
-}
-
-/**
- * Extracts TypeScript entry points from package.json (functional interface).
- *
- * @remarks
- * This is a convenience function that creates an EntryExtractor instance
- * and extracts entries in one call. For repeated use, consider creating
- * an EntryExtractor instance directly.
- *
- * @param packageJson - The package.json object to extract entries from
- * @param options - Configuration options for entry extraction
- * @returns Object containing the extracted entries
- *
- * @public
- */
-export function extractEntriesFromPackageJson(
-	packageJson: PackageJson,
-	options?: EntryExtractorOptions,
-): ExtractedEntries {
-	const extractor = new EntryExtractor(options);
-	return extractor.extract(packageJson);
 }

--- a/test/fixtures/multi-entry/tsdoc.json
+++ b/test/fixtures/multi-entry/tsdoc.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
 	"noStandardTags": false,
-	"reportUnsupportedHtmlElements": false,
+	"reportUnsupportedHtmlElements": true,
 	"supportForTags": {
 		"@deprecated": true,
 		"@label": true,

--- a/test/fixtures/options-testing/tsdoc.json
+++ b/test/fixtures/options-testing/tsdoc.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
 	"noStandardTags": false,
-	"reportUnsupportedHtmlElements": false,
+	"reportUnsupportedHtmlElements": true,
 	"supportForTags": {
 		"@deprecated": true,
 		"@label": true,

--- a/test/fixtures/single-entry/tsdoc.json
+++ b/test/fixtures/single-entry/tsdoc.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
 	"noStandardTags": false,
-	"reportUnsupportedHtmlElements": false,
+	"reportUnsupportedHtmlElements": true,
 	"supportForTags": {
 		"@deprecated": true,
 		"@label": true,

--- a/test/fixtures/with-bin/tsdoc.json
+++ b/test/fixtures/with-bin/tsdoc.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
 	"noStandardTags": false,
-	"reportUnsupportedHtmlElements": false,
+	"reportUnsupportedHtmlElements": true,
 	"supportForTags": {
 		"@deprecated": true,
 		"@label": true,

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
 	"noStandardTags": false,
-	"reportUnsupportedHtmlElements": false,
+	"reportUnsupportedHtmlElements": true,
 	"tagDefinitions": [
 		{
 			"tagName": "@category",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -59,7 +59,16 @@ export default defineConfig({
 			provider: "v8",
 			reporter: ["text", "text-summary", "html", "lcov"],
 			include: ["src/**/*.ts"],
-			exclude: ["**/*.test.ts", "**/__test__/**", "**/types/**", "**/*.d.ts", "**/tsconfig/**", "**/cli/**"],
+			exclude: [
+				"**/*.test.ts",
+				"**/__test__/**",
+				"**/types/**",
+				"**/*.d.ts",
+				"**/tsconfig/**",
+				"**/cli/**",
+				"**/fake/**",
+				"**/shared/**",
+			],
 			thresholds: {
 				perFile: true,
 				statements: 85,


### PR DESCRIPTION
## Summary

- Replace virtual barrel approach with per-entry API Extractor runs merged into a single `.api.json` with multiple `EntryPoint` members
- Add bundleless declaration emission mode — DtsPlugin emits individual `.d.ts` files when `bundle: false` while still generating a merged API model
- Add `exportPaths` to `ExtractedEntries` for lossless entry name to export key mapping
- Enable `reportUnsupportedHtmlElements: true` in TSDoc config
- Remove `extractEntriesFromPackageJson` convenience function; callers use `EntryExtractor` class directly

## Changes

### Multi-entry API model generation

When a package has multiple entry points (e.g., `"."`, `"./nested/one"`, `"./nested/two"`), API Extractor now runs for each entry separately. The per-entry models are merged via `mergeApiModels()` into a single Package with multiple EntryPoint members. Sub-entry canonical references are properly scoped (e.g., `@scope/pkg/nested/one!` instead of `@scope/pkg!`).

### Bundleless mode

DtsPlugin supports `bundle: false` — individual `.d.ts` files are emitted preserving source structure, while API model generation still runs per-entry with merge. The `bundle` and `apiModel` concerns are now independent.

### Virtual barrel removal

The `VirtualBarrelGenerator`, `generateApiModelFromBarrel`, `BarrelApiModelResult`, and `generateVirtualBarrel` option have been removed entirely, replaced by the per-entry merge approach.

### Code simplifications

- Extracted `resolveTsdocMetadataFilename` utility to deduplicate filename resolution (3 occurrences)
- Replaced duplicated CI detection with `TsDocConfigBuilder.isCI()`
- Property shorthand for `bundledPackages`

## Test plan

- [x] All 584 tests pass (527 unit + 57 e2e)
- [x] `pnpm ci:test` passes with coverage thresholds met
- [x] `pnpm typecheck` clean
- [x] `pnpm lint:fix` clean
- [x] Build produces correct multi-entry `.api.json` with 3 EntryPoints and scoped canonical references
- [x] Single-entry build still works correctly (passthrough, no merge)

Signed-off-by: C. Spencer Beggs <spencer@savvyweb.systems>