### PR TITLE
fix: dual format metadata file placement

### DIFF
--- a/.changeset/fair-eagle-302.md
+++ b/.changeset/fair-eagle-302.md
@@ -1,0 +1,9 @@
+---
+"@savvy-web/rslib-builder": patch
+---
+
+Fix dual format builds placing metadata files inside format subdirectories instead of the shared target root.
+
+In dual format builds (`format: ['esm', 'cjs']`), metadata files (package.json, README, LICENSE, api.json, tsdoc-metadata.json, tsconfig.json) were incorrectly placed inside both `esm/` and `cjs/` subdirectories. They now correctly land at the shared `dist/{target}/` root while JS and DTS files route to their respective format subdirectories via `distPath.js` and the new `dtsPathPrefix` option.
+
+Additionally, the `files` array in the output package.json now uses directory entries (`esm`, `cjs`) instead of listing individual files under each format directory, and secondary compilations no longer overwrite the primary's processed package.json.

--- a/.claude/design/rslib-builder/api-extraction.md
+++ b/.claude/design/rslib-builder/api-extraction.md
@@ -14,8 +14,7 @@ dependencies: []
 
 # API Extraction
 
-API model generation and TypeScript declaration bundling using Microsoft's
-API Extractor, with TSDoc configuration support for custom documentation tags.
+API model generation and TypeScript declaration bundling using Microsoft's API Extractor, with TSDoc configuration support for custom documentation tags.
 
 ## Table of Contents
 
@@ -31,10 +30,7 @@ API Extractor, with TSDoc configuration support for custom documentation tags.
 
 ## Overview
 
-The API extraction system generates machine-readable API documentation and
-bundled TypeScript declarations using Microsoft's API Extractor. This enables
-documentation tools (like RSPress plugins) to consume structured API data for
-generating documentation sites.
+The API extraction system generates machine-readable API documentation and bundled TypeScript declarations using Microsoft's API Extractor. This enables documentation tools (like RSPress plugins) to consume structured API data for generating documentation sites.
 
 **Key Features:**
 
@@ -57,17 +53,14 @@ generating documentation sites.
 
 ### What Exists Now
 
-API extraction is handled by the `DtsPlugin` as part of the declaration
-bundling process. When `apiModel` is enabled, API Extractor generates both
-bundled declarations and an API model file.
+API extraction is handled by the `DtsPlugin` as part of the declaration bundling process. When `apiModel` is enabled, API Extractor generates both bundled declarations and an API model file.
 
 **Key Components:**
 
 1. **DtsPlugin** (`src/rslib/plugins/dts-plugin.ts`)
    - Purpose: Generates TypeScript declarations and optional API models
    - Status: Implemented
-   - Key functions: `bundleDtsFiles()`, `mergeApiModels()`,
-     `rewriteCanonicalReferences()`, `DtsPlugin()`
+   - Key functions: `bundleDtsFiles()`, `mergeApiModels()`, `rewriteCanonicalReferences()`, `DtsPlugin()`
 
 2. **ApiModelOptions Interface** (`src/rslib/plugins/dts-plugin.ts`)
    - Purpose: Configuration for API model generation
@@ -77,8 +70,7 @@ bundled declarations and an API model file.
 
 - Generate API model for all entry points (multi-entry support)
   - Per-entry API Extractor runs generate individual `.api.json` files
-  - `mergeApiModels()` combines per-entry models into a single Package
-    with multiple `EntryPoint` members
+  - `mergeApiModels()` combines per-entry models into a single Package with multiple `EntryPoint` members
   - Sub-entry canonical references scoped (e.g., `@scope/pkg/subpath!`)
   - Single-entry packages use the API model as-is (no merge needed)
 - **API model enabled by default** (apiModel: true in DEFAULT_OPTIONS)
@@ -108,8 +100,7 @@ None currently - all planned features have been implemented.
 
 ### Why API Extractor
 
-**Context:** Need to generate machine-readable API documentation for
-documentation sites.
+**Context:** Need to generate machine-readable API documentation for documentation sites.
 
 **Options considered:**
 
@@ -123,13 +114,11 @@ documentation sites.
    - Pros: Full control
    - Cons: Massive effort, reinventing the wheel
 
-**Decision:** API Extractor chosen for its standard `.api.json` format and
-integration with TSDoc for custom tags.
+**Decision:** API Extractor chosen for its standard `.api.json` format and integration with TSDoc for custom tags.
 
 ### Why Tag Groups
 
-**Context:** Users need to define custom TSDoc tags but don't want to
-manually re-enable all standard tags.
+**Context:** Users need to define custom TSDoc tags but don't want to manually re-enable all standard tags.
 
 **Options considered:**
 
@@ -140,14 +129,11 @@ manually re-enable all standard tags.
    - Pros: Ergonomic defaults, explicit control, no external file dependencies
    - Cons: None - tags imported from official `@microsoft/tsdoc` package
 
-**Decision:** Tag groups using `StandardTags` from `@microsoft/tsdoc` package.
-Standard tags are organized into three standardization groups (core, extended,
-discretionary) as defined by the official TSDoc specification.
+**Decision:** Tag groups using `StandardTags` from `@microsoft/tsdoc` package. Standard tags are organized into three standardization groups (core, extended, discretionary) as defined by the official TSDoc specification.
 
 ### Why Smart noStandardTags
 
-**Context:** The `noStandardTags` setting in `tsdoc.json` controls whether
-TSDoc automatically loads standard tags or requires explicit definitions.
+**Context:** The `noStandardTags` setting in `tsdoc.json` controls whether TSDoc automatically loads standard tags or requires explicit definitions.
 
 **Options considered:**
 
@@ -161,17 +147,13 @@ TSDoc automatically loads standard tags or requires explicit definitions.
    - Pros: Minimal config by default, explicit when needed
    - Cons: Slightly more complex logic
 
-**Decision:** When all groups are enabled (default), use `noStandardTags: false`
-to produce minimal config files. When a subset of groups is specified, use
-`noStandardTags: true` and explicitly define only the enabled groups' tags.
+**Decision:** When all groups are enabled (default), use `noStandardTags: false` to produce minimal config files. When a subset of groups is specified, use `noStandardTags: true` and explicitly define only the enabled groups' tags.
 
 ### Why Auto-Derive supportForTags
 
-**Context:** Users had to list custom tags twice (in `tagDefinitions` and
-`supportForTags`).
+**Context:** Users had to list custom tags twice (in `tagDefinitions` and `supportForTags`).
 
-**Decision:** Auto-derive `supportForTags` from all tag definitions. Users
-only need `supportForTags` to explicitly disable specific tags.
+**Decision:** Auto-derive `supportForTags` from all tag definitions. Users only need `supportForTags` to explicitly disable specific tags.
 
 ### Why Persist tsdoc.json by Default (Non-CI)
 
@@ -193,9 +175,7 @@ only need `supportForTags` to explicitly disable specific tags.
    - Pros: Best of both worlds
    - Cons: Slightly more complex logic
 
-**Decision:** Default to persisting `tsdoc.json` in local development
-(tools can read it), but clean up in CI environments where the file serves
-no purpose. CI detection uses `CI` or `GITHUB_ACTIONS` environment variables.
+**Decision:** Default to persisting `tsdoc.json` in local development (tools can read it), but clean up in CI environments where the file serves no purpose. CI detection uses `CI` or `GITHUB_ACTIONS` environment variables.
 
 ---
 
@@ -254,8 +234,7 @@ interface ApiModelOptions {
 }
 ```
 
-**Note:** API model generation is **enabled by default** (`apiModel: true` in
-`NodeLibraryBuilder.DEFAULT_OPTIONS`).
+**Note:** API model generation is **enabled by default** (`apiModel: true` in `NodeLibraryBuilder.DEFAULT_OPTIONS`).
 
 **TsDocOptions** - TSDoc configuration with integrated lint:
 
@@ -318,9 +297,7 @@ ExtractorConfig.prepare({
 
 ### Resolved tsconfig.json
 
-When `apiModel` is enabled, DtsPlugin emits a resolved (flattened) `tsconfig.json`
-to the dist directory. This file is designed for virtual TypeScript environments
-like API Extractor, language services, and documentation tools.
+When `apiModel` is enabled, DtsPlugin emits a resolved (flattened) `tsconfig.json` to the dist directory. This file is designed for virtual TypeScript environments like API Extractor, language services, and documentation tools.
 
 **Purpose:**
 
@@ -332,19 +309,15 @@ like API Extractor, language services, and documentation tools.
 
 - Converts TypeScript enum values to JSON strings (target, module, jsx, etc.)
 - Sets `composite: false` and `noEmit: true` for virtual environment compatibility
-- Excludes path-dependent options: `outDir`, `rootDir`, `baseUrl`, `paths`,
-  `typeRoots`, `declarationDir`
+- Excludes path-dependent options: `outDir`, `rootDir`, `baseUrl`, `paths`, `typeRoots`, `declarationDir`
 - Excludes file selection: `include`, `exclude`, `files`, `references`
 - Removes `types` array to use default @types auto-discovery
-- Converts lib references from full paths (e.g., "lib.esnext.d.ts") to short
-  names (e.g., "esnext")
+- Converts lib references from full paths (e.g., "lib.esnext.d.ts") to short names (e.g., "esnext")
 - Adds `$schema` for IDE support
 
 **Copied to localPaths:**
 
-The resolved tsconfig.json is copied alongside the API model and tsdoc-metadata.json
-when `localPaths` is configured, enabling documentation systems to use accurate
-TypeScript settings for type analysis.
+The resolved tsconfig.json is copied alongside the API model and tsdoc-metadata.json when `localPaths` is configured, enabling documentation systems to use accurate TypeScript settings for type analysis.
 
 ---
 
@@ -352,8 +325,7 @@ TypeScript settings for type analysis.
 
 ### Tag Groups
 
-Standard tags are imported from the official `@microsoft/tsdoc` package and
-organized into three standardization groups:
+Standard tags are imported from the official `@microsoft/tsdoc` package and organized into three standardization groups:
 
 **Core** - Essential TSDoc tags (always needed):
 
@@ -422,9 +394,7 @@ apiModel: {
 
 **Forgotten exports handling:**
 
-A forgotten export occurs when a public API references a declaration that isn't
-exported from the entry point. API Extractor reports these as
-`ae-forgotten-export` messages.
+A forgotten export occurs when a public API references a declaration that isn't exported from the entry point. API Extractor reports these as `ae-forgotten-export` messages.
 
 ```typescript
 // Fail build on forgotten exports
@@ -446,17 +416,11 @@ apiModel: {
 }
 ```
 
-The `forgottenExports` option uses the same `messageCallback` mechanism as
-TSDoc warnings. Messages with `messageId === "ae-forgotten-export"` are
-intercepted and handled according to the setting. For `"include"` and
-`"error"`, messages are collected and formatted using the shared
-`formatWarning` helper after `Extractor.invoke()` completes.
+The `forgottenExports` option uses the same `messageCallback` mechanism as TSDoc warnings. Messages with `messageId === "ae-forgotten-export"` are intercepted and handled according to the setting. For `"include"` and `"error"`, messages are collected and formatted using the shared `formatWarning` helper after `Extractor.invoke()` completes.
 
 ### Generated tsdoc.json
 
-The plugin generates a `tsdoc.json` file with smart `noStandardTags` handling.
-Note: `supportForTags` is always populated because API Extractor requires explicit
-support declarations for each tag (defining tags isn't sufficient).
+The plugin generates a `tsdoc.json` file with smart `noStandardTags` handling. Note: `supportForTags` is always populated because API Extractor requires explicit support declarations for each tag (defining tags isn't sufficient).
 
 **Default (all groups enabled):**
 
@@ -495,9 +459,7 @@ support declarations for each tag (defining tags isn't sufficient).
 
 ### Config Persistence Behavior
 
-The `persistConfig` option (nested under `apiModel.tsdoc.lint`) controls whether
-`tsdoc.json` remains on disk. In CI environments, persistence validates the
-existing file instead of writing:
+The `persistConfig` option (nested under `apiModel.tsdoc.lint`) controls whether `tsdoc.json` remains on disk. In CI environments, persistence validates the existing file instead of writing:
 
 | Environment | `persistConfig` | Behavior |
 | ----------- | --------------- | -------- |
@@ -511,10 +473,7 @@ existing file instead of writing:
 
 **CI Detection:** Environment variables `CI=true` or `GITHUB_ACTIONS=true`.
 
-**Validation in CI:** When `persistConfig` is true or undefined in CI, the
-existing `tsdoc.json` is validated against the expected configuration. If it
-doesn't match, the build fails with an error instructing the developer to
-regenerate the file locally and commit the changes.
+**Validation in CI:** When `persistConfig` is true or undefined in CI, the existing `tsdoc.json` is validated against the expected configuration. If it doesn't match, the build fails with an error instructing the developer to regenerate the file locally and commit the changes.
 
 **Usage examples:**
 
@@ -607,8 +566,7 @@ Integration with API Extractor is difficult to unit test. Rely on:
 
 ---
 
-**Document Status:** Current - All features implemented including multi-entry
-API model generation with per-entry API Extractor runs and model merging.
+**Document Status:** Current - All features implemented including multi-entry API model generation with per-entry API Extractor runs and model merging.
 
 **Implementation:**
 

--- a/.claude/design/rslib-builder/api-model-options.md
+++ b/.claude/design/rslib-builder/api-model-options.md
@@ -29,8 +29,7 @@ Quick reference for configuring API model generation in the DtsPlugin.
 
 ## Overview
 
-The `ApiModelOptions` interface configures API model generation for TypeScript
-packages using Microsoft's API Extractor. When enabled, it generates:
+The `ApiModelOptions` interface configures API model generation for TypeScript packages using Microsoft's API Extractor. When enabled, it generates:
 
 - `<package>.api.json` - Machine-readable API documentation for tooling
 - `tsdoc-metadata.json` - TSDoc tag metadata for downstream consumers
@@ -88,9 +87,7 @@ interface TsDocTagDefinition {
 }
 ```
 
-**Note:** API model generation is **enabled by default** (`apiModel: true` in
-`NodeLibraryBuilder.DEFAULT_OPTIONS`). TSDoc linting is controlled via
-`apiModel.tsdoc.lint` and is also enabled by default when `apiModel` is enabled.
+**Note:** API model generation is **enabled by default** (`apiModel: true` in `NodeLibraryBuilder.DEFAULT_OPTIONS`). TSDoc linting is controlled via `apiModel.tsdoc.lint` and is also enabled by default when `apiModel` is enabled.
 
 ---
 
@@ -98,9 +95,7 @@ interface TsDocTagDefinition {
 
 ### ApiModelOptions
 
-**Note:** API model generation is **enabled by default**. The `apiModel` option
-defaults to `true` in `NodeLibraryBuilder.DEFAULT_OPTIONS`. To disable API
-model generation, explicitly set `apiModel: false`.
+**Note:** API model generation is **enabled by default**. The `apiModel` option defaults to `true` in `NodeLibraryBuilder.DEFAULT_OPTIONS`. To disable API model generation, explicitly set `apiModel: false`.
 
 ```typescript
 // API model enabled by default (implicit)
@@ -127,8 +122,7 @@ NodeLibraryBuilder.create({
 | Default | `<unscopedPackageName>.api.json` |
 | Required | No |
 
-Custom filename for the generated API model file. The default follows API
-Extractor conventions using the unscoped package name.
+Custom filename for the generated API model file. The default follows API Extractor conventions using the unscoped package name.
 
 ```typescript
 // Package "@savvy-web/rslib-builder" generates "rslib-builder.api.json"
@@ -146,8 +140,7 @@ apiModel: { enabled: true, filename: "api.json" }
 | Default | `undefined` |
 | Required | No |
 
-Local directory paths to copy API model and related files after build
-completes. Used for local development with documentation systems.
+Local directory paths to copy API model and related files after build completes. Used for local development with documentation systems.
 
 **Files copied:**
 
@@ -176,8 +169,7 @@ apiModel: {
 | Default | All standard tag groups enabled |
 | Required | No |
 
-TSDoc configuration for custom tag definitions. See [TsDocOptions](#tsdocoptions)
-section for detailed configuration.
+TSDoc configuration for custom tag definitions. See [TsDocOptions](#tsdocoptions) section for detailed configuration.
 
 #### `tsdocMetadata`
 
@@ -187,8 +179,7 @@ section for detailed configuration.
 | Default | `true` (enabled when apiModel is enabled) |
 | Required | No |
 
-Options for `tsdoc-metadata.json` generation. This file is required by the
-TSDoc specification to be included in published packages.
+Options for `tsdoc-metadata.json` generation. This file is required by the TSDoc specification to be included in published packages.
 
 ```typescript
 // Enable with defaults
@@ -212,9 +203,7 @@ apiModel: { enabled: true, tsdocMetadata: false }
 | Default | `"include"` |
 | Required | No |
 
-Controls handling of API Extractor's "forgotten export" (`ae-forgotten-export`)
-messages. A forgotten export occurs when a public API references a declaration
-that isn't exported from the entry point.
+Controls handling of API Extractor's "forgotten export" (`ae-forgotten-export`) messages. A forgotten export occurs when a public API references a declaration that isn't exported from the entry point.
 
 | Value | Behavior |
 | ----- | -------- |
@@ -222,11 +211,7 @@ that isn't exported from the entry point.
 | `"error"` | Fail the build with details about forgotten exports |
 | `"ignore"` | Suppress all forgotten export messages silently |
 
-**Implementation:** In the `messageCallback` passed to `Extractor.invoke()`,
-messages with `messageId === "ae-forgotten-export"` are intercepted. For
-`"include"` and `"error"`, messages are collected into a
-`collectedForgottenExports` array and formatted using the same `formatWarning`
-helper shared with TSDoc warning handling.
+**Implementation:** In the `messageCallback` passed to `Extractor.invoke()`, messages with `messageId === "ae-forgotten-export"` are intercepted. For `"include"` and `"error"`, messages are collected into a `collectedForgottenExports` array and formatted using the same `formatWarning` helper shared with TSDoc warning handling.
 
 ```typescript
 // Fail build on forgotten exports
@@ -241,10 +226,7 @@ apiModel: { enabled: true }
 
 ### TsDocOptions
 
-**Integrated Lint Configuration:** TSDoc linting is now controlled via the
-`apiModel.tsdoc.lint` option. When `apiModel` is enabled (the default), lint
-is also enabled by default. The lint plugin uses the TSDoc tag configuration
-from the parent `tsdoc` object (tagDefinitions, groups, etc.).
+**Integrated Lint Configuration:** TSDoc linting is now controlled via the `apiModel.tsdoc.lint` option. When `apiModel` is enabled (the default), lint is also enabled by default. The lint plugin uses the TSDoc tag configuration from the parent `tsdoc` object (tagDefinitions, groups, etc.).
 
 #### `groups`
 
@@ -258,11 +240,8 @@ TSDoc tag groups to enable. Standard tags are imported from `@microsoft/tsdoc`.
 
 **Groups:**
 
-- **core:** `@param`, `@returns`, `@remarks`, `@deprecated`, `@typeParam`,
-  `@link`, `@label`, `@packageDocumentation`, `@privateRemarks`
-- **extended:** `@example`, `@defaultValue`, `@throws`, `@see`, `@inheritDoc`,
-  `@virtual`, `@override`, `@sealed`, `@readonly`, `@eventProperty`,
-  `@decorator`, `@jsx`, `@jsxFrag`, `@jsxImportSource`, `@jsxRuntime`
+- **core:** `@param`, `@returns`, `@remarks`, `@deprecated`, `@typeParam`, `@link`, `@label`, `@packageDocumentation`, `@privateRemarks`
+- **extended:** `@example`, `@defaultValue`, `@throws`, `@see`, `@inheritDoc`, `@virtual`, `@override`, `@sealed`, `@readonly`, `@eventProperty`, `@decorator`, `@jsx`, `@jsxFrag`, `@jsxImportSource`, `@jsxRuntime`
 - **discretionary:** `@alpha`, `@beta`, `@experimental`, `@public`, `@internal`
 
 ```typescript
@@ -284,8 +263,7 @@ tsdoc: { groups: ["core", "discretionary"] }
 | Default | `[]` |
 | Required | No |
 
-Custom TSDoc tag definitions beyond standard groups. Tags are automatically
-added to `supportForTags` (no need to declare twice).
+Custom TSDoc tag definitions beyond standard groups. Tags are automatically added to `supportForTags` (no need to declare twice).
 
 ```typescript
 tsdoc: {
@@ -304,8 +282,7 @@ tsdoc: {
 | Default | Auto-derived from groups + tagDefinitions |
 | Required | No |
 
-Override support for specific tags. **Only needed to disable tags.** Tags from
-enabled groups and custom definitions are auto-supported.
+Override support for specific tags. **Only needed to disable tags.** Tags from enabled groups and custom definitions are auto-supported.
 
 ```typescript
 // Disable @beta even though "discretionary" group is enabled
@@ -322,8 +299,7 @@ tsdoc: {
 | Default | `true` (enabled when apiModel is enabled) |
 | Required | No |
 
-Controls TSDoc linting before the build. Lint is enabled by default when
-`apiModel` is enabled.
+Controls TSDoc linting before the build. Lint is enabled by default when `apiModel` is enabled.
 
 ```typescript
 // Lint enabled by default (apiModel: true is the default)
@@ -357,10 +333,7 @@ apiModel: {
 | `onError` | `TsDocLintErrorBehavior` | `"throw"` in CI, `"error"` locally | Error handling behavior |
 | `persistConfig` | `boolean \| PathLike` | `true` locally | Persist tsdoc.json (validates in CI) |
 
-**Lint persistence behavior in CI:** When `persistConfig` is `true` or undefined
-in CI environments, the existing `tsdoc.json` is validated against the expected
-configuration. If it doesn't match, the build fails with instructions to
-regenerate locally. Set `persistConfig: false` to skip validation.
+**Lint persistence behavior in CI:** When `persistConfig` is `true` or undefined in CI environments, the existing `tsdoc.json` is validated against the expected configuration. If it doesn't match, the build fails with instructions to regenerate locally. Set `persistConfig: false` to skip validation.
 
 #### `warnings`
 
@@ -488,22 +461,13 @@ export default NodeLibraryBuilder.create({
 
 ### Multi-Entry API Model Generation
 
-When a package has multiple entry points, API Extractor runs for each entry
-and generates a per-entry `.api.json` file in a temp directory. These are
-then merged into a single Package with multiple `EntryPoint` members via
-`mergeApiModels()`.
+When a package has multiple entry points, API Extractor runs for each entry and generates a per-entry `.api.json` file in a temp directory. These are then merged into a single Package with multiple `EntryPoint` members via `mergeApiModels()`.
 
 **Single entry:** The per-entry API model is used as-is (no merge step).
 
-**Multiple entries:** Each per-entry model's `EntryPoint` is extracted,
-canonical references for sub-entries are rewritten to include the export
-subpath (e.g., `@scope/pkg/utils!` instead of `@scope/pkg!`), and all
-`EntryPoint` members are combined into one Package. The main entry (".")
-is always first in the members array.
+**Multiple entries:** Each per-entry model's `EntryPoint` is extracted, canonical references for sub-entries are rewritten to include the export subpath (e.g., `@scope/pkg/utils!` instead of `@scope/pkg!`), and all `EntryPoint` members are combined into one Package. The main entry (".") is always first in the members array.
 
-The `exportPaths` mapping from `EntryExtractor` provides the lossless
-reverse mapping from entry names back to original export keys for correct
-canonical reference scoping.
+The `exportPaths` mapping from `EntryExtractor` provides the lossless reverse mapping from entry names back to original export keys for correct canonical reference scoping.
 
 ### File Distribution
 
@@ -516,24 +480,15 @@ canonical reference scoping.
 
 ### localPaths Behavior
 
-- **Skipped in CI:** When `CI=true` or `GITHUB_ACTIONS=true`, localPaths
-  copying is skipped to avoid polluting CI environments.
+- **Skipped in CI:** When `CI=true` or `GITHUB_ACTIONS=true`, localPaths copying is skipped to avoid polluting CI environments.
 
-- **Atomic copy after build:** Files are copied in `onCloseBuild` hook after
-  all assets are written to dist. This ensures the transformed `package.json`
-  (with resolved pnpm references and updated paths) is copied, not the source.
+- **Atomic copy after build:** Files are copied in `onCloseBuild` hook after all assets are written to dist. This ensures the transformed `package.json` (with resolved pnpm references and updated paths) is copied, not the source.
 
-- **Directory creation:** Final directory is created if it doesn't exist, but
-  parent directories must exist. This prevents accidental creation of deep
-  directory trees from typos.
+- **Directory creation:** Final directory is created if it doesn't exist, but parent directories must exist. This prevents accidental creation of deep directory trees from typos.
 
 ### TSDoc Config Optimization
 
-When all tag groups are enabled (the default), the generated `tsdoc.json`
-uses `noStandardTags: false` to let TSDoc automatically load all standard
-tags, producing a minimal config file. When a subset of groups is specified,
-`noStandardTags: true` is used and only the enabled groups' tags are
-explicitly defined.
+When all tag groups are enabled (the default), the generated `tsdoc.json` uses `noStandardTags: false` to let TSDoc automatically load all standard tags, producing a minimal config file. When a subset of groups is specified, `noStandardTags: true` is used and only the enabled groups' tags are explicitly defined.
 
 ---
 
@@ -541,10 +496,8 @@ explicitly defined.
 
 **Internal Design Docs:**
 
-- [Architecture](./architecture.md) - Overall system architecture and plugin
-  execution model
-- [API Extraction](./api-extraction.md) - Detailed API extraction process and
-  TSDoc configuration rationale
+- [Architecture](./architecture.md) - Overall system architecture and plugin execution model
+- [API Extraction](./api-extraction.md) - Detailed API extraction process and TSDoc configuration rationale
 
 **Source Code:**
 
@@ -553,13 +506,10 @@ explicitly defined.
 
 **External Resources:**
 
-- [API Extractor](https://api-extractor.com/) - Microsoft's API documentation
-  tool
+- [API Extractor](https://api-extractor.com/) - Microsoft's API documentation tool
 - [TSDoc](https://tsdoc.org/) - Documentation comment standard
-- [tsdoc.json Configuration](https://api-extractor.com/pages/configs/tsdoc_json/)
-  - TSDoc config file reference
+- [tsdoc.json Configuration](https://api-extractor.com/pages/configs/tsdoc_json/) - TSDoc config file reference
 
 ---
 
-**Document Status:** Current - Comprehensive reference for ApiModelOptions
-configuration with multi-entry API model generation support.
+**Document Status:** Current - Comprehensive reference for ApiModelOptions configuration with multi-entry API model generation support.

--- a/.claude/design/rslib-builder/architecture.md
+++ b/.claude/design/rslib-builder/architecture.md
@@ -14,10 +14,7 @@ dependencies: []
 
 # RSlib Builder - Architecture
 
-A sophisticated build system abstraction layer built on RSlib/Rsbuild/Rspack,
-providing a fluent API for building TypeScript packages with multi-target
-support, automatic package.json transformation, and TypeScript declaration
-bundling.
+A sophisticated build system abstraction layer built on RSlib/Rsbuild/Rspack, providing a fluent API for building TypeScript packages with multi-target support, automatic package.json transformation, and TypeScript declaration bundling.
 
 ## Table of Contents
 
@@ -35,25 +32,16 @@ bundling.
 
 ## Overview
 
-`@savvy-web/rslib-builder` provides a high-level `NodeLibraryBuilder` API that
-simplifies building TypeScript packages for multiple targets (dev, npm). It
-handles automatic configuration generation, plugin orchestration, and complex
-package.json transformations.
+`@savvy-web/rslib-builder` provides a high-level `NodeLibraryBuilder` API that simplifies building TypeScript packages for multiple targets (dev, npm). It handles automatic configuration generation, plugin orchestration, and complex package.json transformations.
 
-The system features a plugin-based architecture where plugins operate at
-different Rsbuild asset processing stages, collectively transforming raw
-TypeScript source into production-ready distributions with proper type
-declarations, export mappings, and dependency resolution.
+The system features a plugin-based architecture where plugins operate at different Rsbuild asset processing stages, collectively transforming raw TypeScript source into production-ready distributions with proper type declarations, export mappings, and dependency resolution.
 
 **Key Design Principles:**
 
-- **Abstraction over complexity**: Hide RSlib/Rsbuild configuration details
-  behind a fluent API
-- **Plugin composition**: Modular plugins handle specific concerns (entries,
-  types, transforms)
+- **Abstraction over complexity**: Hide RSlib/Rsbuild configuration details behind a fluent API
+- **Plugin composition**: Modular plugins handle specific concerns (entries, types, transforms)
 - **Multi-target support**: Single configuration produces dev and npm builds
-- **Convention over configuration**: Sensible defaults with escape hatches for
-  customization
+- **Convention over configuration**: Sensible defaults with escape hatches for customization
 - **Self-building**: The package builds itself using its own NodeLibraryBuilder
 
 **When to reference this document:**
@@ -73,8 +61,7 @@ declarations, export mappings, and dependency resolution.
 
 **Location:** `src/rslib/builders/node-library-builder.ts`
 
-**Purpose:** Main public API providing a fluent interface for building Node.js
-libraries.
+**Purpose:** Main public API providing a fluent interface for building Node.js libraries.
 
 **Responsibilities:**
 
@@ -121,8 +108,7 @@ NodeLibraryBuilder.DEFAULT_OPTIONS = {
 NodeLibraryBuilder.create(options): RslibConfigAsyncFn
 ```
 
-**Note:** TSDoc linting is controlled via `apiModel.tsdoc.lint` option (not a separate
-top-level option). Lint is enabled by default when `apiModel` is enabled.
+**Note:** TSDoc linting is controlled via `apiModel.tsdoc.lint` option (not a separate top-level option). Lint is enabled by default when `apiModel` is enabled.
 
 **Dependencies:**
 
@@ -133,8 +119,7 @@ top-level option). Lint is enabled by default when `apiModel` is enabled.
 
 **Location:** `src/rslib/plugins/`
 
-**Purpose:** Modular build transformations operating at specific Rsbuild asset
-processing stages.
+**Purpose:** Modular build transformations operating at specific Rsbuild asset processing stages.
 
 **Plugins:**
 
@@ -150,8 +135,7 @@ processing stages.
   - Stages: modifyRsbuildConfig, pre-process, summarize, onCloseBuild
   - When apiModel enabled: emits tsconfig.json, api model, tsdoc-metadata.json
   - API model is enabled by default for npm target
-  - Multi-entry: runs API Extractor per entry, merges into single `.api.json`
-    with multiple `EntryPoint` members via `mergeApiModels()`
+  - Multi-entry: runs API Extractor per entry, merges into single `.api.json` with multiple `EntryPoint` members via `mergeApiModels()`
   - Format-aware: emits `.d.cts` for CJS entries, `.d.ts` for ESM entries
 - **PackageJsonTransformPlugin** - Transform package.json for dist
   - Stages: pre-process, optimize, optimize-inline
@@ -165,16 +149,14 @@ processing stages.
 
 **Location:** `src/rslib/plugins/utils/`
 
-**Purpose:** Shared utilities for entry extraction, package.json building, and
-transformations. Consolidated from 14 files to 6 focused modules.
+**Purpose:** Shared utilities for entry extraction, package.json building, and transformations. Consolidated from 14 files to 6 focused modules.
 
 **Consolidated structure (6 files):**
 
 1. **`build-logger.ts`** - Build logging and timing utilities
    - Consolidated from: `time-utils.ts`, `logger-utils.ts`
    - Exports: `createTimer()`, `formatTime()`, `createEnvLogger()`
-   - Provides formatted build logging with test suppression and duration
-     tracking
+   - Provides formatted build logging with test suppression and duration tracking
 
 2. **`asset-utils.ts`** - Asset handling utilities
    - Consolidated from: `json-asset-utils.ts`, `asset-processor-utils.ts`
@@ -184,51 +166,35 @@ transformations. Consolidated from 14 files to 6 focused modules.
 3. **`file-utils.ts`** - File system utilities
    - Consolidated with: `dependency-path-utils.ts`
    - Exports: `fileExistAsync()`, `packageJsonVersion()`, `getApiExtractorPath()`
-   - File existence checks, package version reading, API Extractor path
-     resolution
+   - File existence checks, package version reading, API Extractor path resolution
 
 4. **`package-json-transformer.ts`** - Package.json transformation pipeline
-   - Consolidated from: `bin-transform-utils.ts`, `export-transform-utils.ts`,
-     `path-transform-utils.ts`, `rslib-transform-utils.ts`,
-     `pnpm-transform-utils.ts`, `package-json-builder-utils.ts`,
-     `package-json-types-utils.ts`
-   - Exports: `buildPackageJson()`, `transformExportPath()`, `createTypePath()`,
-     `transformPackageExports()`, `transformPackageBin()`,
-     `applyRslibTransformations()`, `applyPnpmTransformations()`
-   - Orchestrates pnpm + RSlib transformation pipeline, handles exports/bin
-     fields, path transformations, type conditions
+   - Consolidated from: `bin-transform-utils.ts`, `export-transform-utils.ts`, `path-transform-utils.ts`, `rslib-transform-utils.ts`, `pnpm-transform-utils.ts`, `package-json-builder-utils.ts`, `package-json-types-utils.ts`
+   - Exports: `buildPackageJson()`, `transformExportPath()`, `createTypePath()`, `transformPackageExports()`, `transformPackageBin()`, `applyRslibTransformations()`, `applyPnpmTransformations()`
+   - Orchestrates pnpm + RSlib transformation pipeline, handles exports/bin fields, path transformations, type conditions
 
 5. **`workspace-catalog.ts`** - Multi-package-manager workspace catalog resolution
    - Exports: `WorkspaceCatalog` class, `createWorkspaceCatalog()` factory
    - Multi-package-manager support via `workspace-tools`:
-     - **pnpm**: Reads from `pnpm-lock.yaml` (primary, for config dependency
-       catalogs like `catalog:silk`) then falls back to `pnpm-workspace.yaml`
+     - **pnpm**: Reads from `pnpm-lock.yaml` (primary, for config dependency catalogs like `catalog:silk`) then falls back to `pnpm-workspace.yaml`
      - **yarn**: Uses `workspace-tools`'s `getCatalogs()` function
      - Other package managers return empty catalogs
    - Factory pattern for dependency injection:
      - `createWorkspaceCatalog()` returns new instances (no global singleton)
      - Plugins can create, cache, and share their own instances
-     - `applyPnpmTransformations()` accepts optional `catalog?: WorkspaceCatalog`
-       parameter for DI
-   - Named catalog support: Handles `catalog:default`, `catalog:silk`,
-     `catalog:tools`, etc.
-   - Validation: Validates referenced catalogs exist before resolution with
-     clear error messages showing available catalogs
-   - Logging: Shows which catalog each dependency was resolved from
-     (e.g., `@microsoft/api-extractor: ^7.56.0 (catalog:silk)`)
+     - `applyPnpmTransformations()` accepts optional `catalog?: WorkspaceCatalog` parameter for DI
+   - Named catalog support: Handles `catalog:default`, `catalog:silk`, `catalog:tools`, etc.
+   - Validation: Validates referenced catalogs exist before resolution with clear error messages showing available catalogs
+   - Logging: Shows which catalog each dependency was resolved from (e.g., `@microsoft/api-extractor: ^7.56.0 (catalog:silk)`)
 
 6. **`entry-extractor.ts`** - Entry point extraction
    - Exports: `EntryExtractor` class, `ExtractedEntries` interface
    - Class-based entry extraction from package.json exports/bin fields
-   - `ExtractedEntries` contains `entries` (name-to-source mapping) and
-     `exportPaths` (name-to-original-export-key mapping, e.g.,
-     `"nested-one"` -> `"./nested/one"`)
-   - `exportPaths` enables lossless reverse mapping for multi-entry API
-     model canonical references
+   - `ExtractedEntries` contains `entries` (name-to-source mapping) and `exportPaths` (name-to-original-export-key mapping, e.g., `"nested-one"` -> `"./nested/one"`)
+   - `exportPaths` enables lossless reverse mapping for multi-entry API model canonical references
 
 7. **`import-graph.ts`** - TypeScript import graph analysis
-   - Exports: `ImportGraph` class, `ImportGraphOptions`, `ImportGraphResult`,
-     `ImportGraphError`, `ImportGraphErrorType`
+   - Exports: `ImportGraph` class, `ImportGraphOptions`, `ImportGraphResult`, `ImportGraphError`, `ImportGraphErrorType`
    - Traces imports from entry points to discover all reachable TypeScript files
    - Uses TypeScript compiler API for accurate module resolution
    - Filters test files, declaration files, and node_modules
@@ -236,8 +202,7 @@ transformations. Consolidated from 14 files to 6 focused modules.
    - Supports configurable exclude patterns for custom filtering
 
 8. **`tsconfig-resolver.ts`** - TypeScript config resolution for virtual environments
-   - Exports: `TsconfigResolver` class, `TsconfigResolverError`,
-     `ResolvedTsconfig`, `ResolvedCompilerOptions`, standalone converter functions
+   - Exports: `TsconfigResolver` class, `TsconfigResolverError`, `ResolvedTsconfig`, `ResolvedCompilerOptions`, standalone converter functions
    - Converts TypeScript's `ParsedCommandLine` to JSON-serializable format
    - Static methods for enum conversion (ScriptTarget, ModuleKind, JsxEmit, etc.)
    - Sets `composite: false` and `noEmit: true` for virtual environment compatibility
@@ -250,8 +215,7 @@ transformations. Consolidated from 14 files to 6 focused modules.
 
 **Location:** `src/rslib/builders/node-library-builder.ts` (createSingleTarget)
 
-**Purpose:** Generate multiple LibConfig entries when the build requires
-different output formats for different entries.
+**Purpose:** Generate multiple LibConfig entries when the build requires different output formats for different entries.
 
 **Responsibilities:**
 
@@ -293,8 +257,7 @@ lib: [
 
 **Location:** `src/rslib/plugins/utils/package-json-transformer.ts`
 
-Post-processing step that transforms standard `{ types, import }` conditions
-into format-specific conditions:
+Post-processing step that transforms standard `{ types, import }` conditions into format-specific conditions:
 
 - `toCjsPath()` - `.js` → `.cjs`
 - `toCtsTypePath()` - `.d.ts` → `.d.cts`
@@ -358,16 +321,14 @@ into format-specific conditions:
 
 #### Decision 1: Plugin-Based Architecture
 
-**Context:** Need modular, testable build transformations that can be composed
-differently per target.
+**Context:** Need modular, testable build transformations that can be composed differently per target.
 
 **Options considered:**
 
 1. **Plugin composition (Chosen):**
    - Pros: Modular, testable, reusable across targets
    - Cons: Complexity of shared state management
-   - Why chosen: Aligns with Rsbuild's extension model, enables fine-grained
-     control
+   - Why chosen: Aligns with Rsbuild's extension model, enables fine-grained control
 
 2. **Monolithic build function:**
    - Pros: Simpler control flow, no shared state concerns
@@ -376,8 +337,7 @@ differently per target.
 
 #### Decision 2: Shared State via api.expose()
 
-**Context:** Plugins need to share data (entries, files array) across execution
-stages.
+**Context:** Plugins need to share data (entries, files array) across execution stages.
 
 **Options considered:**
 
@@ -425,16 +385,14 @@ stages.
 
 #### Decision 5: Two-Stage Package.json Transformation
 
-**Context:** Need to resolve pnpm references and transform paths for
-distribution.
+**Context:** Need to resolve pnpm references and transform paths for distribution.
 
 **Options considered:**
 
 1. **Separate pnpm and RSlib stages (Chosen):**
    - Pros: Clear separation of concerns, easier debugging
    - Cons: Two-pass transformation
-   - Why chosen: pnpm catalog/workspace resolution must happen before path
-     transformation
+   - Why chosen: pnpm catalog/workspace resolution must happen before path transformation
 
 2. **Single-pass transformation:**
    - Pros: Potentially faster
@@ -443,17 +401,14 @@ distribution.
 
 #### Decision 6: Pre-Build TSDoc Validation
 
-**Context:** Need to catch TSDoc documentation errors early, before declaration
-generation and API model creation.
+**Context:** Need to catch TSDoc documentation errors early, before declaration generation and API model creation.
 
 **Options considered:**
 
 1. **onBeforeBuild hook (Chosen):**
-   - Pros: Runs before all plugins, fails fast on doc errors, no wasted
-     compilation time
+   - Pros: Runs before all plugins, fails fast on doc errors, no wasted compilation time
    - Cons: Adds latency before build starts
-   - Why chosen: Documentation errors should block the build early, not after
-     expensive TypeScript compilation
+   - Why chosen: Documentation errors should block the build early, not after expensive TypeScript compilation
 
 2. **processAssets pre-process stage:**
    - Pros: Runs alongside other plugins
@@ -467,8 +422,7 @@ generation and API model creation.
 
 #### Decision 7: Environment-Aware Error Handling
 
-**Context:** TSDoc errors should fail CI builds but not block local development
-iteration.
+**Context:** TSDoc errors should fail CI builds but not block local development iteration.
 
 **Options considered:**
 
@@ -510,11 +464,8 @@ iteration.
 #### Pattern 4: Factory with Instance Caching
 
 - **Where used:** WorkspaceCatalog class
-- **Why used:** Avoid repeated filesystem operations while enabling DI and
-  plugin-level caching
-- **Implementation:** Factory function `createWorkspaceCatalog()` returns new
-  instances; each instance caches catalog data and workspace root internally;
-  plugins can create and share instances via dependency injection
+- **Why used:** Avoid repeated filesystem operations while enabling DI and plugin-level caching
+- **Implementation:** Factory function `createWorkspaceCatalog()` returns new instances; each instance caches catalog data and workspace root internally; plugins can create and share instances via dependency injection
 
 #### Pattern 5: Chain of Responsibility
 
@@ -540,8 +491,7 @@ iteration.
 
 - **What we gained:** Simple shared state with api.expose()
 - **What we sacrificed:** Compile-time type safety for shared state
-- **Why it's worth it:** Rsbuild's pattern is well-understood, runtime checks
-  suffice
+- **Why it's worth it:** Rsbuild's pattern is well-understood, runtime checks suffice
 
 ---
 
@@ -686,9 +636,7 @@ iteration.
 
 **Location:** `src/rslib/plugins/utils/import-graph.ts`
 
-**Purpose:** Analyzes TypeScript import relationships to discover all files
-reachable from specified entry points. Used by TsDocLintPlugin to automatically
-determine which files need TSDoc validation.
+**Purpose:** Analyzes TypeScript import relationships to discover all files reachable from specified entry points. Used by TsDocLintPlugin to automatically determine which files need TSDoc validation.
 
 **Key interfaces:**
 
@@ -785,23 +733,17 @@ for (const error of result.errors) {
 }
 ```
 
-**Integration with EntryExtractor:** ImportGraph uses EntryExtractor internally
-when tracing from package.json exports. EntryExtractor parses the `exports`
-and `bin` fields, then ImportGraph traces imports from those entry points.
+**Integration with EntryExtractor:** ImportGraph uses EntryExtractor internally when tracing from package.json exports. EntryExtractor parses the `exports` and `bin` fields, then ImportGraph traces imports from those entry points.
 
 ---
 
 ### TsDocLintPlugin Configuration
 
-The TsDocLintPlugin validates TSDoc comments before the build starts using
-ESLint with `eslint-plugin-tsdoc`. It shares TSDoc configuration with the
-DtsPlugin through the `TsDocConfigBuilder` utility.
+The TsDocLintPlugin validates TSDoc comments before the build starts using ESLint with `eslint-plugin-tsdoc`. It shares TSDoc configuration with the DtsPlugin through the `TsDocConfigBuilder` utility.
 
 **Configuration via apiModel.tsdoc.lint:**
 
-TSDoc linting is now configured through the `apiModel.tsdoc.lint` option in
-`NodeLibraryBuilderOptions`. Lint is enabled by default when `apiModel` is
-enabled (which is the default).
+TSDoc linting is now configured through the `apiModel.tsdoc.lint` option in `NodeLibraryBuilderOptions`. Lint is enabled by default when `apiModel` is enabled (which is the default).
 
 ```typescript
 // Lint enabled by default (apiModel: true is the default)
@@ -845,9 +787,7 @@ type TsDocLintErrorBehavior = "warn" | "error" | "throw";
 
 **Automatic file discovery (default behavior):**
 
-By default, TsDocLintPlugin uses ImportGraph to automatically discover files
-from your package's exports. This ensures only public API files are linted,
-not internal implementation details or test files.
+By default, TsDocLintPlugin uses ImportGraph to automatically discover files from your package's exports. This ensures only public API files are linted, not internal implementation details or test files.
 
 The discovery process:
 
@@ -858,8 +798,7 @@ The discovery process:
 
 **The `include` option (override automatic discovery):**
 
-Use the `include` option when you need to lint specific files that are not
-part of the export graph, or to override automatic discovery entirely:
+Use the `include` option when you need to lint specific files that are not part of the export graph, or to override automatic discovery entirely:
 
 ```typescript
 apiModel: {
@@ -887,14 +826,11 @@ Controls how TSDoc lint errors are handled:
 | `"error"` | Log errors, continue build (default local) |
 | `"throw"` | Fail build immediately (default CI) |
 
-Environment detection uses `CI` or `GITHUB_ACTIONS` environment variables
-to determine if running in CI.
+Environment detection uses `CI` or `GITHUB_ACTIONS` environment variables to determine if running in CI.
 
 **The `persistConfig` option (tsdoc.json management):**
 
-Controls whether the generated `tsdoc.json` configuration file is kept after
-linting. In CI environments, this validates the existing file matches expected
-configuration instead of writing.
+Controls whether the generated `tsdoc.json` configuration file is kept after linting. In CI environments, this validates the existing file matches expected configuration instead of writing.
 
 | Value | Local Behavior | CI Behavior |
 | --- | --- | --- |
@@ -1333,11 +1269,9 @@ ImportGraph.traceFromPackageExports()
 
 - **@pnpm/exportable-manifest**: Resolve pnpm catalog/workspace references
 - **@pnpm/lockfile.fs**: Read `pnpm-lock.yaml` for config dependency catalogs
-- **@pnpm/workspace.read-manifest**: Read `pnpm-workspace.yaml` for traditional
-  catalog definitions
+- **@pnpm/workspace.read-manifest**: Read `pnpm-workspace.yaml` for traditional catalog definitions
 - **@pnpm/catalogs.config**: Normalize catalogs from workspace manifest
-- **@pnpm/catalogs.protocol-parser**: Parse `catalog:name` specifiers to
-  extract catalog names
+- **@pnpm/catalogs.protocol-parser**: Parse `catalog:name` specifiers to extract catalog names
 - **@pnpm/types**: Type definitions for pnpm manifests
 - **sort-package-json**: Consistent package.json field ordering
 - **type-fest**: PackageJson type definitions
@@ -1345,8 +1279,7 @@ ImportGraph.traceFromPackageExports()
 **Workspace Detection and Catalog Resolution:**
 
 - **workspace-tools**: Multi-package-manager workspace support
-  - `getWorkspaceManagerAndRoot()`: Detect package manager (pnpm, yarn, npm,
-    etc.) and workspace root
+  - `getWorkspaceManagerAndRoot()`: Detect package manager (pnpm, yarn, npm, etc.) and workspace root
   - `getCatalogs()`: Read yarn workspace catalogs
 
 **Utilities:**
@@ -1360,8 +1293,7 @@ ImportGraph.traceFromPackageExports()
 
 ### Co-Located Test Structure
 
-Tests are co-located with source files for better discoverability and
-maintenance:
+Tests are co-located with source files for better discoverability and maintenance:
 
 ```text
 src/
@@ -1446,8 +1378,7 @@ expect(config.environments.development.source).toHaveProperty('entry');
 Shared test helpers remain in the `__test__` directory:
 
 - `types/test-types.ts` - Mock asset types (`MockAsset`, `MockAssetRegistry`)
-- `utils/test-types.ts` - Utility functions (`createMockStats()`,
-  `createMockProcessAssetsContext()`)
+- `utils/test-types.ts` - Utility functions (`createMockStats()`, `createMockProcessAssetsContext()`)
 
 **Type-safe mocks:**
 
@@ -1477,8 +1408,7 @@ pnpm test:coverage
 pnpm test:watch
 ```
 
-For comprehensive testing strategy details, see
-[testing-strategy.md](./testing-strategy.md).
+For comprehensive testing strategy details, see [testing-strategy.md](./testing-strategy.md).
 
 ---
 
@@ -1507,8 +1437,7 @@ For comprehensive testing strategy details, see
 
 **Internal Design Docs:**
 
-- [API Extraction](./api-extraction.md) - API model generation and TSDoc
-  configuration (TsDocLintPlugin shares tsdoc options with DtsPlugin)
+- [API Extraction](./api-extraction.md) - API model generation and TSDoc configuration (TsDocLintPlugin shares tsdoc options with DtsPlugin)
 
 **Package Documentation:**
 
@@ -1518,8 +1447,7 @@ For comprehensive testing strategy details, see
 **External Resources:**
 
 - [RSlib Documentation](https://rslib.dev/) - Build system documentation
-- [Rsbuild Plugin API](https://rsbuild.dev/plugins/dev/core) - Plugin
-  development
+- [Rsbuild Plugin API](https://rsbuild.dev/plugins/dev/core) - Plugin development
 - [Rspack](https://rspack.dev/) - Underlying bundler
 - [API Extractor](https://api-extractor.com/) - Declaration bundling
 - [PNPM Workspace](https://pnpm.io/workspaces) - Workspace configuration
@@ -1527,12 +1455,6 @@ For comprehensive testing strategy details, see
 
 ---
 
-**Document Status:** Current - Core architecture documented with all components
-including ImportGraph analysis, TsDocLintPlugin file discovery, multi-entry
-API model generation with per-entry API Extractor runs and merge, multi-
-package-manager workspace catalog resolution (pnpm, yarn) with factory pattern
-for dependency injection, and multi-format build system (dual format, per-entry
-format overrides, format-aware DTS and export conditions)
+**Document Status:** Current - Core architecture documented with all components including ImportGraph analysis, TsDocLintPlugin file discovery, multi-entry API model generation with per-entry API Extractor runs and merge, multi-package-manager workspace catalog resolution (pnpm, yarn) with factory pattern for dependency injection, and multi-format build system (dual format, per-entry format overrides, format-aware DTS and export conditions)
 
-**Next Steps:** Add sequence diagrams for complex flows, document edge cases in
-transformation pipeline
+**Next Steps:** Add sequence diagrams for complex flows, document edge cases in transformation pipeline

--- a/.claude/design/rslib-builder/testing-strategy.md
+++ b/.claude/design/rslib-builder/testing-strategy.md
@@ -13,8 +13,7 @@ dependencies: []
 
 # RSlib Builder - Testing Strategy
 
-Comprehensive testing approach for @savvy-web/rslib-builder using Vitest with
-v8 coverage, co-located test files, and type-safe mocking patterns.
+Comprehensive testing approach for @savvy-web/rslib-builder using Vitest with v8 coverage, co-located test files, and type-safe mocking patterns.
 
 ## Table of Contents
 
@@ -38,10 +37,8 @@ The testing strategy for `@savvy-web/rslib-builder` prioritizes:
 
 - **Co-location**: Test files live next to source files for discoverability
 - **Type safety**: No `any` types; all mocks use proper interfaces
-- **High coverage**: 85% per-file thresholds for statements, branches,
-  functions, and lines
-- **Isolation**: Unit tests mock external dependencies; integration tests use
-  real APIs
+- **High coverage**: 85% per-file thresholds for statements, branches, functions, and lines
+- **Isolation**: Unit tests mock external dependencies; integration tests use real APIs
 - **Fast feedback**: Vitest provides instant re-runs in watch mode
 
 **When to reference this document:**
@@ -57,8 +54,7 @@ The testing strategy for `@savvy-web/rslib-builder` prioritizes:
 
 ### Test Organization
 
-Tests follow a co-located structure where test files sit alongside their
-source files:
+Tests follow a co-located structure where test files sit alongside their source files:
 
 ```text
 src/
@@ -142,8 +138,7 @@ Located in `test/e2e/utils/`:
 
 ### Why Co-Located Tests?
 
-**Decision:** Place test files next to source files rather than in a separate
-`__tests__` directory.
+**Decision:** Place test files next to source files rather than in a separate `__tests__` directory.
 
 **Benefits:**
 
@@ -447,8 +442,7 @@ mockReadFile.mockResolvedValue('{"name": "test"}');
 
 ### Mock Rsbuild API
 
-Plugins receive an `api` object in their `setup()` function. Create type-safe
-mocks:
+Plugins receive an `api` object in their `setup()` function. Create type-safe mocks:
 
 ```typescript
 const plugin = AutoEntryPlugin();
@@ -617,9 +611,7 @@ describe("MyPlugin", () => {
 
 ## E2E Testing Infrastructure
 
-End-to-end tests verify the complete build pipeline by building real fixture
-packages and asserting on the generated outputs. This catches integration issues
-that unit tests cannot detect.
+End-to-end tests verify the complete build pipeline by building real fixture packages and asserting on the generated outputs. This catches integration issues that unit tests cannot detect.
 
 ### Fixture Structure
 
@@ -713,8 +705,7 @@ describe("My tests", () => {
 });
 ```
 
-The `result` context provides automatic cleanup - just set `result.value` to
-your build result and the isolated fixture is cleaned up automatically.
+The `result` context provides automatic cleanup - just set `result.value` to your build result and the isolated fixture is cleaned up automatically.
 
 #### assertions.ts
 
@@ -979,10 +970,8 @@ expect(() => mySyncFn()).toThrow("Expected error message");
 
 - [architecture.md](./architecture.md) - System architecture overview
 - [Vitest Documentation](https://vitest.dev/) - Test framework reference
-- [Rsbuild Plugin API](https://rsbuild.dev/plugins/dev/core) - Plugin testing
-  patterns
+- [Rsbuild Plugin API](https://rsbuild.dev/plugins/dev/core) - Plugin testing patterns
 
 ---
 
-**Document Status:** Current - Comprehensive testing strategy documented with
-unit testing patterns, E2E testing infrastructure, and CI integration.
+**Document Status:** Current - Comprehensive testing strategy documented with unit testing patterns, E2E testing infrastructure, and CI integration.

--- a/.claude/design/rslib-builder/tsdoc-lint-options.md
+++ b/.claude/design/rslib-builder/tsdoc-lint-options.md
@@ -16,16 +16,11 @@ dependencies: []
 
 # TsDocLintPlugin Configuration (Archived)
 
-**This document is archived.** TSDoc linting configuration has been integrated
-into the `apiModel.tsdoc.lint` option. See
-[api-model-options.md](./api-model-options.md) for the current configuration
-reference.
+**This document is archived.** TSDoc linting configuration has been integrated into the `apiModel.tsdoc.lint` option. See [api-model-options.md](./api-model-options.md) for the current configuration reference.
 
 ## Migration Guide
 
-The `tsdocLint` option no longer exists as a separate top-level option in
-`NodeLibraryBuilderOptions`. TSDoc linting is now controlled via
-`apiModel.tsdoc.lint`.
+The `tsdocLint` option no longer exists as a separate top-level option in `NodeLibraryBuilderOptions`. TSDoc linting is now controlled via `apiModel.tsdoc.lint`.
 
 ### Before (Old Configuration)
 
@@ -61,13 +56,10 @@ NodeLibraryBuilder.create({
 
 ### Key Changes
 
-1. **Default behavior**: Lint is enabled by default when `apiModel` is enabled
-   (which is also the default)
+1. **Default behavior**: Lint is enabled by default when `apiModel` is enabled (which is also the default)
 2. **Configuration location**: Moved from `tsdocLint` to `apiModel.tsdoc.lint`
-3. **TSDoc config sharing**: The lint plugin automatically uses tag definitions
-   from the parent `apiModel.tsdoc` object
-4. **Persistence in CI**: When `persistConfig` is true/undefined in CI, the
-   existing `tsdoc.json` is validated instead of written
+3. **TSDoc config sharing**: The lint plugin automatically uses tag definitions from the parent `apiModel.tsdoc` object
+4. **Persistence in CI**: When `persistConfig` is true/undefined in CI, the existing `tsdoc.json` is validated instead of written
 
 ### Disabling Lint
 

--- a/.claude/design/rslib-builder/virtual-entries.md
+++ b/.claude/design/rslib-builder/virtual-entries.md
@@ -14,9 +14,7 @@ dependencies: []
 
 # Virtual Entries Feature
 
-A feature to support bundling additional entry points with custom output names that
-bypass type generation and package.json exports while still being included in the
-published package.
+A feature to support bundling additional entry points with custom output names that bypass type generation and package.json exports while still being included in the published package.
 
 ## Table of Contents
 
@@ -33,13 +31,9 @@ published package.
 
 ## Overview
 
-The `virtualEntries` feature allows bundling additional entry points with custom output
-names without generating TypeScript declarations or adding them to package.json exports.
-These are "virtual" in the sense that they exist outside the standard entry point
-workflow while using the same bundling machinery.
+The `virtualEntries` feature allows bundling additional entry points with custom output names without generating TypeScript declarations or adding them to package.json exports. These are "virtual" in the sense that they exist outside the standard entry point workflow while using the same bundling machinery.
 
-**Primary Use Case:** pnpm config dependencies require a `pnpmfile.cjs` file that must
-be CommonJS, self-contained (no external requires), and doesn't need type declarations.
+**Primary Use Case:** pnpm config dependencies require a `pnpmfile.cjs` file that must be CommonJS, self-contained (no external requires), and doesn't need type declarations.
 
 **Key Characteristics:**
 
@@ -64,8 +58,7 @@ be CommonJS, self-contained (no external requires), and doesn't need type declar
 
 ### Implemented API
 
-The `virtualEntries` option and top-level `format` option are implemented in
-`NodeLibraryBuilderOptions`:
+The `virtualEntries` option and top-level `format` option are implemented in `NodeLibraryBuilderOptions`:
 
 ```typescript
 interface VirtualEntryConfig {
@@ -128,8 +121,7 @@ interface NodeLibraryBuilderOptions {
 2. **Mixed**: Regular entries + virtual entries
 3. **Virtual-only**: No regular entries, only virtual entries
 
-Virtual-only configurations are valid for packages that exist solely to provide
-special files (like pnpmfile.cjs) without exposing a programmatic API.
+Virtual-only configurations are valid for packages that exist solely to provide special files (like pnpmfile.cjs) without exposing a programmatic API.
 
 ### Behavior Matrix
 
@@ -146,16 +138,14 @@ special files (like pnpmfile.cjs) without exposing a programmatic API.
 
 ### Package.json Type Field
 
-The top-level `format` option determines the `type` field in the transformed
-package.json:
+The top-level `format` option determines the `type` field in the transformed package.json:
 
 | Format | package.json type |
 | --- | --- |
 | `"esm"` (default) | `"type": "module"` |
 | `"cjs"` | `"type": "commonjs"` |
 
-This ensures Node.js correctly interprets the module format of the published
-package.
+This ensures Node.js correctly interprets the module format of the published package.
 
 ### Implementation Approach
 
@@ -163,8 +153,7 @@ There are two viable approaches for implementing virtual entries:
 
 #### Approach A: Separate RSlib `lib` Configs (Recommended)
 
-Create additional RSlib `lib` configurations for virtual entries that need different
-formats. This leverages RSlib's existing multi-lib support.
+Create additional RSlib `lib` configurations for virtual entries that need different formats. This leverages RSlib's existing multi-lib support.
 
 **Pros:**
 
@@ -180,8 +169,7 @@ formats. This leverages RSlib's existing multi-lib support.
 
 #### Approach B: Single Config with Custom Plugin
 
-Process virtual entries within a custom Rsbuild plugin that handles the different
-format requirements.
+Process virtual entries within a custom Rsbuild plugin that handles the different format requirements.
 
 **Pros:**
 
@@ -194,8 +182,7 @@ format requirements.
 - May conflict with RSlib's format assumptions
 - Harder to maintain
 
-**Decision:** Approach A (separate lib configs) is recommended for its cleaner
-architecture and native format support.
+**Decision:** Approach A (separate lib configs) is recommended for its cleaner architecture and native format support.
 
 ---
 
@@ -205,8 +192,7 @@ architecture and native format support.
 
 #### Decision 1: Separate lib Configs for Format Isolation
 
-**Context:** Virtual entries may require different formats (CJS vs ESM) than the
-main library build.
+**Context:** Virtual entries may require different formats (CJS vs ESM) than the main library build.
 
 **Options considered:**
 
@@ -259,8 +245,7 @@ main library build.
 
 #### Decision 4: Virtual Entries Not Added to package.json Exports
 
-**Context:** Virtual entries are special files that shouldn't be importable as
-package exports.
+**Context:** Virtual entries are special files that shouldn't be importable as package exports.
 
 **Rationale:**
 
@@ -272,8 +257,7 @@ package exports.
 
 #### Pattern: Configuration Aggregation
 
-Virtual entries are aggregated into the RSlib configuration alongside regular
-entries, but routed to separate lib configs when formats differ.
+Virtual entries are aggregated into the RSlib configuration alongside regular entries, but routed to separate lib configs when formats differ.
 
 ```typescript
 // Pseudo-code for config generation
@@ -566,9 +550,7 @@ for (const [entryName, sourcePath] of Object.entries(entries)) {
 
 **Resolved tsconfig.json format alignment:**
 
-When outputting the resolved `tsconfig.json` for virtual TS environments, it must
-reflect the actual compilation format. Since the source is always ESM, but the
-output may be CJS, the tsconfig needs adjustment:
+When outputting the resolved `tsconfig.json` for virtual TS environments, it must reflect the actual compilation format. Since the source is always ESM, but the output may be CJS, the tsconfig needs adjustment:
 
 ```typescript
 // In DtsPlugin, when emitting resolved tsconfig.json
@@ -589,14 +571,11 @@ const resolvedTsConfig = {
 };
 ```
 
-This ensures tools consuming the resolved tsconfig.json (like virtual TS
-environments, documentation generators, or IDE integrations) correctly understand
-the module format of the compiled output.
+This ensures tools consuming the resolved tsconfig.json (like virtual TS environments, documentation generators, or IDE integrations) correctly understand the module format of the compiled output.
 
 ### AutoEntryPlugin Changes
 
-No changes needed - AutoEntryPlugin processes package.json exports, and virtual
-entries are not in exports. The plugin naturally ignores them.
+No changes needed - AutoEntryPlugin processes package.json exports, and virtual entries are not in exports. The plugin naturally ignores them.
 
 ### FilesArrayPlugin Changes
 
@@ -626,9 +605,7 @@ const format = api.useExposed<"esm" | "cjs">("library-format") ?? "esm";
 packageJson.type = format === "esm" ? "module" : "commonjs";
 ```
 
-**No changes for exports** - virtual entries don't affect package.json exports
-transformation. The plugin only processes entries from the `entrypoints` map
-exposed by AutoEntryPlugin, which excludes virtual entries.
+**No changes for exports** - virtual entries don't affect package.json exports transformation. The plugin only processes entries from the `entrypoints` map exposed by AutoEntryPlugin, which excludes virtual entries.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,6 @@
 # @savvy-web/rslib-builder
 
-RSlib-based build system for modern ESM Node.js libraries. Provides `NodeLibraryBuilder`
-API and plugin system for TypeScript packages.
+RSlib-based build system for modern ESM Node.js libraries. Provides `NodeLibraryBuilder` API and plugin system for TypeScript packages.
 
 ## Package Overview
 
@@ -103,8 +102,7 @@ All plugins and utilities have co-located `.test.ts` files.
 
 #### NodeLibraryBuilder
 
-The main API for building Node.js libraries. Provides a fluent interface for
-RSlib builds.
+The main API for building Node.js libraries. Provides a fluent interface for RSlib builds.
 
 **Location**: `src/rslib/builders/node-library-builder.ts`
 
@@ -177,8 +175,7 @@ const mockAssets: MockAssetRegistry = {
 
 ### E2E Tests
 
-E2E tests verify builder options by building isolated fixture copies with
-dynamically generated configs:
+E2E tests verify builder options by building isolated fixture copies with dynamically generated configs:
 
 - `test/e2e/dts-bundling.test.ts` - DTS bundling for single/multi-entry fixtures
 - `test/e2e/builder-options/api-model.test.ts` - API model generation options
@@ -216,8 +213,7 @@ pnpm lint:fix           # Auto-fix lint issues
 pnpm typecheck          # Type-check all workspaces
 ```
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for full development workflow and
-troubleshooting.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for full development workflow and troubleshooting.
 
 ## External Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
 # Contributing to @savvy-web/rslib-builder
 
-Thank you for your interest in contributing! This guide covers the development
-workflow and standards for this project.
+Thank you for your interest in contributing! This guide covers the development workflow and standards for this project.
 
 ## Prerequisites
 
@@ -138,11 +137,9 @@ rslib-builder/
 
 When adding or modifying plugins:
 
-1. Plugins execute in order: TsDocLintPlugin (pre-build) → AutoEntryPlugin →
-   DtsPlugin → PackageJsonTransformPlugin → VirtualEntryPlugin → FilesArrayPlugin
+1. Plugins execute in order: TsDocLintPlugin (pre-build) → AutoEntryPlugin → DtsPlugin → PackageJsonTransformPlugin → VirtualEntryPlugin → FilesArrayPlugin
 2. Use `api.expose()` / `api.useExposed()` for cross-plugin state
-3. Understand Rsbuild `processAssets` stages: `pre-process`, `optimize`,
-   `additional`, `optimize-inline`, `summarize`
+3. Understand Rsbuild `processAssets` stages: `pre-process`, `optimize`, `additional`, `optimize-inline`, `summarize`
 
 See `.claude/design/rslib-builder/architecture.md` for detailed plugin architecture.
 
@@ -176,9 +173,7 @@ See `.claude/design/rslib-builder/architecture.md` for detailed plugin architect
 
 ## Developer Certificate of Origin (DCO)
 
-This project requires all contributions to be signed off under the
-[Developer Certificate of Origin (DCO)](./DCO). This certifies that you have
-the right to submit your contribution under the project's open source license.
+This project requires all contributions to be signed off under the [Developer Certificate of Origin (DCO)](./DCO). This certifies that you have the right to submit your contribution under the project's open source license.
 
 ### How to Sign Off
 
@@ -222,6 +217,4 @@ git config user.email "your.email@example.com"
 
 ## License
 
-By contributing and signing off your commits, you agree that your contributions
-will be licensed under the MIT License and certify compliance with the
-[Developer Certificate of Origin](./DCO).
+By contributing and signing off your commits, you agree that your contributions will be licensed under the MIT License and certify compliance with the [Developer Certificate of Origin](./DCO).

--- a/README.md
+++ b/README.md
@@ -4,30 +4,17 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D24.0.0-brightgreen)](https://nodejs.org)
 
-Build modern ESM Node.js libraries with minimal configuration. Handles
-TypeScript declarations, package.json transformations, and PNPM workspace
-resolution automatically.
+Build modern ESM Node.js libraries with minimal configuration. Handles TypeScript declarations, package.json transformations, and PNPM workspace resolution automatically.
 
 ## Features
 
-- **Zero-Config Entry Detection** - Auto-discovers
-  entry points from package.json exports
-- **10-100x Faster Types** - Uses tsgo (native
-  TypeScript compiler) with API Extractor for
-  bundled, clean public API declarations
-- **Production-Ready Transforms** - Converts `.ts`
-  exports to `.js`, resolves PNPM `catalog:` and
-  `workspace:` references, generates files array
-- **Bundled or Bundleless** - Choose single-file
-  bundles per entry or bundleless mode that
-  preserves your source file structure
-- **Multi-Target Builds** - Separate dev (with
-  source maps) and npm (optimized) outputs from a
-  single configuration
-- **Flexible Formats** - ESM, CJS, or dual format
-  output with per-entry format overrides
-- **TSDoc Validation** - Pre-build documentation
-  validation with automatic public API discovery
+- **Zero-Config Entry Detection** - Auto-discovers entry points from package.json exports
+- **10-100x Faster Types** - Uses tsgo (native TypeScript compiler) with API Extractor for bundled, clean public API declarations
+- **Production-Ready Transforms** - Converts `.ts` exports to `.js`, resolves PNPM `catalog:` and `workspace:` references, generates files array
+- **Bundled or Bundleless** - Choose single-file bundles per entry or bundleless mode that preserves your source file structure
+- **Multi-Target Builds** - Separate dev (with source maps) and npm (optimized) outputs from a single configuration
+- **Flexible Formats** - ESM, CJS, or dual format output with per-entry format overrides
+- **TSDoc Validation** - Pre-build documentation validation with automatic public API discovery
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/savvy-web/rslib-builder.git"
+		"url": "git+https://github.com/savvy-web/rslib-builder.git"
 	},
 	"license": "MIT",
 	"author": {

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -2,7 +2,6 @@ import { NodeLibraryBuilder } from "./src/index.js";
 
 // Use our own builder - self-building example
 export default NodeLibraryBuilder.create({
-	bundle: true,
 	// Generate API model for npm target (used by documentation tooling)
 	// Set RSLIB_BUILDER_LOCAL_PATH env var for local API model path resolution
 	apiModel: {

--- a/src/rslib/builders/node-library-builder.test.ts
+++ b/src/rslib/builders/node-library-builder.test.ts
@@ -70,8 +70,10 @@ vi.mock("../plugins/utils/entry-extractor.js", () => ({
 	},
 }));
 
-// Import mocked AutoEntryPlugin to inspect calls
+// Import mocked plugins to inspect calls
 import { AutoEntryPlugin } from "../plugins/auto-entry-plugin.js";
+import { DtsPlugin } from "../plugins/dts-plugin.js";
+import { FilesArrayPlugin } from "../plugins/files-array-plugin.js";
 
 describe("NodeLibraryBuilder", () => {
 	beforeEach(() => {
@@ -301,6 +303,87 @@ describe("NodeLibraryBuilder", () => {
 
 			const lib = capturedConfig?.lib?.[0];
 			expect(lib?.output?.legalComments).toBeUndefined();
+		});
+
+		describe("dual format", () => {
+			it("should set distPath.root to baseOutputDir and distPath.js to primary format", async () => {
+				const options = NodeLibraryBuilder.mergeOptions({ format: ["esm", "cjs"] });
+				await NodeLibraryBuilder.createSingleTarget("npm", options);
+
+				const primaryLib = capturedConfig?.lib?.[0];
+				expect(primaryLib?.output?.distPath).toEqual({ root: "dist/npm", js: "esm" });
+			});
+
+			it("should set distPath.js to secondary format on secondary lib config", async () => {
+				const options = NodeLibraryBuilder.mergeOptions({ format: ["esm", "cjs"] });
+				await NodeLibraryBuilder.createSingleTarget("npm", options);
+
+				const secondaryLib = capturedConfig?.lib?.[1];
+				expect(secondaryLib?.output?.distPath).toEqual({ root: "dist/npm", js: "cjs" });
+			});
+
+			it("should set outBase to baseOutputDir for both primary and secondary in bundle mode", async () => {
+				const options = NodeLibraryBuilder.mergeOptions({ format: ["esm", "cjs"], bundle: true });
+				await NodeLibraryBuilder.createSingleTarget("npm", options);
+
+				const primaryLib = capturedConfig?.lib?.[0];
+				const secondaryLib = capturedConfig?.lib?.[1];
+				expect(primaryLib?.outBase).toBe("dist/npm");
+				expect(secondaryLib?.outBase).toBe("dist/npm");
+			});
+
+			it("should pass dtsPathPrefix to primary DtsPlugin", async () => {
+				const options = NodeLibraryBuilder.mergeOptions({ format: ["esm", "cjs"] });
+				await NodeLibraryBuilder.createSingleTarget("npm", options);
+
+				// Primary DtsPlugin is the last call (called after secondary)
+				const dtsCalls = vi.mocked(DtsPlugin).mock.calls;
+				const primaryCall = dtsCalls[0][0];
+				expect(primaryCall).toMatchObject({ dtsPathPrefix: "esm" });
+			});
+
+			it("should pass dtsPathPrefix to secondary DtsPlugin", async () => {
+				const options = NodeLibraryBuilder.mergeOptions({ format: ["esm", "cjs"] });
+				await NodeLibraryBuilder.createSingleTarget("npm", options);
+
+				const dtsCalls = vi.mocked(DtsPlugin).mock.calls;
+				const secondaryCall = dtsCalls[1][0];
+				expect(secondaryCall).toMatchObject({ dtsPathPrefix: "cjs" });
+			});
+
+			it("should not set distPath.js for single format builds", async () => {
+				const options = NodeLibraryBuilder.mergeOptions({ format: "esm" });
+				await NodeLibraryBuilder.createSingleTarget("npm", options);
+
+				const lib = capturedConfig?.lib?.[0];
+				expect(lib?.output?.distPath).toEqual({ root: "dist/npm" });
+			});
+
+			it("should not pass dtsPathPrefix to DtsPlugin for single format", async () => {
+				const options = NodeLibraryBuilder.mergeOptions({ format: "esm" });
+				await NodeLibraryBuilder.createSingleTarget("npm", options);
+
+				const dtsCalls = vi.mocked(DtsPlugin).mock.calls;
+				expect(dtsCalls[0][0]).not.toHaveProperty("dtsPathPrefix");
+			});
+
+			it("should pass formatDirs with all formats to primary FilesArrayPlugin", async () => {
+				const options = NodeLibraryBuilder.mergeOptions({ format: ["esm", "cjs"] });
+				await NodeLibraryBuilder.createSingleTarget("npm", options);
+
+				// Primary FilesArrayPlugin is the first call
+				const filesCalls = vi.mocked(FilesArrayPlugin).mock.calls;
+				const primaryCall = filesCalls[0][0];
+				expect(primaryCall).toMatchObject({ formatDirs: ["esm", "cjs"] });
+			});
+
+			it("should not pass formatDirs for single format", async () => {
+				const options = NodeLibraryBuilder.mergeOptions({ format: "esm" });
+				await NodeLibraryBuilder.createSingleTarget("npm", options);
+
+				const filesCalls = vi.mocked(FilesArrayPlugin).mock.calls;
+				expect(filesCalls[0][0]).not.toHaveProperty("formatDirs");
+			});
 		});
 	});
 });

--- a/src/rslib/builders/node-library-builder.ts
+++ b/src/rslib/builders/node-library-builder.ts
@@ -710,8 +710,6 @@ export class NodeLibraryBuilder {
 
 		// Build output configuration
 		const baseOutputDir = `dist/${target}`;
-		// For dual format, each format gets its own subdirectory
-		const outputDir = isDualFormat ? `${baseOutputDir}/${primaryFormat}` : baseOutputDir;
 
 		// Only enable API model generation for npm target (not dev)
 		const apiModelForTarget = target === "npm" ? options.apiModel : undefined;
@@ -761,6 +759,7 @@ export class NodeLibraryBuilder {
 			FilesArrayPlugin({
 				target,
 				...(options.transformFiles && { transformFiles: options.transformFiles }),
+				...(isDualFormat && { formatDirs: formats }),
 			}),
 		);
 
@@ -778,12 +777,13 @@ export class NodeLibraryBuilder {
 				buildTarget: target,
 				format: primaryFormat,
 				...(apiModelForTarget !== undefined && { apiModel: apiModelForTarget }),
+				...(isDualFormat && { dtsPathPrefix: primaryFormat }),
 			}),
 		);
 
 		const lib: LibConfig = {
 			id: isDualFormat ? `${target}-${primaryFormat}` : target,
-			outBase: !bundle ? "src" : outputDir,
+			outBase: !bundle ? "src" : baseOutputDir,
 			output: {
 				target: "node",
 				module: true,
@@ -791,7 +791,8 @@ export class NodeLibraryBuilder {
 				sourceMap,
 				...bundlelessOutput,
 				distPath: {
-					root: outputDir,
+					root: baseOutputDir,
+					...(isDualFormat && { js: primaryFormat }),
 				},
 				copy: {
 					patterns: options.copyPatterns,
@@ -835,11 +836,24 @@ export class NodeLibraryBuilder {
 			// Create additional LibConfigs for secondary formats (dual format)
 			if (isDualFormat) {
 				for (const secondaryFormat of formats.slice(1)) {
-					const secondaryOutputDir = `${baseOutputDir}/${secondaryFormat}`;
 					const secondaryPlugins: RsbuildPlugin[] = [
 						// No AutoEntryPlugin - entries are shared from primary
 						// No PackageJsonTransformPlugin - primary handles package.json
-						FilesArrayPlugin({ target }),
+						// No FilesArrayPlugin - primary uses directory entries to cover all formats
+						// Strip metadata assets that RSlib auto-copies, so they don't overwrite
+						// the primary's processed versions (package.json, README, LICENSE)
+						{
+							name: "strip-metadata-assets",
+							setup(api) {
+								api.processAssets({ stage: "additional" }, (context) => {
+									for (const name of Object.keys(context.compilation.assets)) {
+										if (name === "package.json" || name === "README.md" || name === "LICENSE") {
+											delete context.compilation.assets[name];
+										}
+									}
+								});
+							},
+						},
 						DtsPlugin({
 							...(options.tsconfigPath && { tsconfigPath: options.tsconfigPath }),
 							abortOnError: true,
@@ -847,19 +861,21 @@ export class NodeLibraryBuilder {
 							...(options.dtsBundledPackages && { bundledPackages: options.dtsBundledPackages }),
 							buildTarget: target,
 							format: secondaryFormat,
+							dtsPathPrefix: secondaryFormat,
 						}),
 					];
 
 					const secondaryLib: LibConfig = {
 						id: `${target}-${secondaryFormat}`,
-						outBase: !bundle ? "src" : secondaryOutputDir,
+						outBase: !bundle ? "src" : baseOutputDir,
 						output: {
 							target: "node",
 							cleanDistPath: false,
 							sourceMap,
 							...bundlelessOutput,
 							distPath: {
-								root: secondaryOutputDir,
+								root: baseOutputDir,
+								js: secondaryFormat,
 							},
 							...externalsConfig,
 						},

--- a/src/rslib/plugins/dts-plugin.ts
+++ b/src/rslib/plugins/dts-plugin.ts
@@ -750,6 +750,14 @@ export interface DtsPluginOptions {
 	 * The API model is excluded from npm publish (not added to `files` array).
 	 */
 	apiModel?: ApiModelOptions | boolean;
+
+	/**
+	 * Path prefix for emitted DTS files.
+	 * Used in dual format builds to place declarations in format subdirectories
+	 * (e.g., `esm/index.d.ts`, `cjs/index.d.cts`).
+	 * Metadata files (api.json, tsdoc-metadata.json, tsconfig.json) are NOT prefixed.
+	 */
+	dtsPathPrefix?: string;
 }
 
 /**
@@ -1656,10 +1664,14 @@ export const DtsPlugin = (options: DtsPluginOptions = {}): RsbuildPlugin => {
 									outputPath = outputPath.replace(/\.d\.ts$/, dtsExtension);
 								}
 
+								// Apply dtsPathPrefix for dual format builds
+								const prefixedPath = options.dtsPathPrefix ? `${options.dtsPathPrefix}/${outputPath}` : outputPath;
+
 								// Only emit .d.ts for files that have a corresponding .js in the compilation
 								// tsgo generates declarations for all files in tsconfig scope, but we only
 								// want declarations for files that are in the JS compilation (import graph)
-								const jsOutputPath = outputPath.replace(/\.d\.(ts|mts|cts)$/, ".js");
+								// Use prefixed path since JS files also have format prefix from distPath.js
+								const jsOutputPath = prefixedPath.replace(/\.d\.(ts|mts|cts)$/, ".js");
 								if (!context.compilation.assets[jsOutputPath]) {
 									continue;
 								}
@@ -1670,13 +1682,13 @@ export const DtsPlugin = (options: DtsPluginOptions = {}): RsbuildPlugin => {
 								content = stripSourceMapComment(content);
 
 								// Create source and emit asset
-								const source = new context.sources.OriginalSource(content, outputPath);
-								context.compilation.emitAsset(outputPath, source);
+								const source = new context.sources.OriginalSource(content, prefixedPath);
+								context.compilation.emitAsset(prefixedPath, source);
 								emittedCount++;
 
 								// Add .d.ts files to files array
-								if (filesArray && outputPath.endsWith(".d.ts")) {
-									filesArray.add(outputPath);
+								if (filesArray && prefixedPath.endsWith(".d.ts")) {
+									filesArray.add(prefixedPath);
 								}
 							}
 
@@ -1807,16 +1819,21 @@ export const DtsPlugin = (options: DtsPluginOptions = {}): RsbuildPlugin => {
 											// For CJS format, use .d.cts extension
 											const bundledFileName = `${entryName}${bundledDtsExtension}`;
 
+											// Apply dtsPathPrefix for dual format builds
+											const prefixedBundledFileName = options.dtsPathPrefix
+												? `${options.dtsPathPrefix}/${bundledFileName}`
+												: bundledFileName;
+
 											// Read from temp and strip sourceMappingURL comment before emitting
 											let content = await readFile(tempBundledPath, "utf-8");
 											content = stripSourceMapComment(content);
-											const source = new context.sources.OriginalSource(content, bundledFileName);
-											context.compilation.emitAsset(bundledFileName, source);
+											const source = new context.sources.OriginalSource(content, prefixedBundledFileName);
+											context.compilation.emitAsset(prefixedBundledFileName, source);
 											emittedCount++;
 
 											// Add .d.ts file to files array (but not .d.ts.map files)
 											if (filesArray) {
-												filesArray.add(bundledFileName);
+												filesArray.add(prefixedBundledFileName);
 											}
 										}
 
@@ -1863,7 +1880,7 @@ export const DtsPlugin = (options: DtsPluginOptions = {}): RsbuildPlugin => {
 												hasTsdocMetadata: !!tsdocMetadataPath,
 												hasTsconfig: !!state.parsedConfig && !!state.tsconfigPath,
 												cwd,
-												distPath: `dist/${envId}`,
+												distPath: `dist/${options.buildTarget ?? envId}`,
 											});
 										}
 									}
@@ -1925,7 +1942,11 @@ export const DtsPlugin = (options: DtsPluginOptions = {}): RsbuildPlugin => {
 									if (options.bundle) {
 										for (const [entryName] of bundledFiles) {
 											const bundledFileName = `${entryName}${bundledDtsExtension}`;
-											const mapFileName = `${bundledFileName}.map`;
+											// Use prefixed path for map file cleanup (matches emitted asset path)
+											const prefixedBundledFileName = options.dtsPathPrefix
+												? `${options.dtsPathPrefix}/${bundledFileName}`
+												: bundledFileName;
+											const mapFileName = `${prefixedBundledFileName}.map`;
 
 											for (const file of dtsFiles) {
 												if (file.relativePath.endsWith(".d.ts.map")) {
@@ -1938,9 +1959,13 @@ export const DtsPlugin = (options: DtsPluginOptions = {}): RsbuildPlugin => {
 												if (dtsExtension !== ".d.ts" && outputPath.endsWith(".d.ts")) {
 													outputPath = outputPath.replace(/\.d\.ts$/, dtsExtension);
 												}
-												const mapFileName = `${outputPath}.map`;
-												if (context.compilation.assets[mapFileName]) {
-													delete context.compilation.assets[mapFileName];
+												// Apply prefix for individual DTS map cleanup
+												const prefixedOutputPath = options.dtsPathPrefix
+													? `${options.dtsPathPrefix}/${outputPath}`
+													: outputPath;
+												const individualMapFileName = `${prefixedOutputPath}.map`;
+												if (context.compilation.assets[individualMapFileName]) {
+													delete context.compilation.assets[individualMapFileName];
 												}
 											}
 

--- a/src/rslib/plugins/files-array-plugin.test.ts
+++ b/src/rslib/plugins/files-array-plugin.test.ts
@@ -475,6 +475,82 @@ describe("FilesArrayPlugin", () => {
 		expect(Array.from(exposedSet).sort()).toEqual(["README.md", "package.json"]);
 	});
 
+	it("should add formatDirs to files array in additional stage", async () => {
+		const plugin = FilesArrayPlugin({ target: "npm", formatDirs: ["esm", "cjs"] });
+
+		const mockApi = {
+			processAssets: vi.fn(),
+			useExposed: vi.fn().mockReturnValue(undefined),
+			expose: vi.fn(),
+		};
+
+		// biome-ignore lint/suspicious/noExplicitAny: Test mocks
+		const mockPackageJsonAsset = { fileName: "package.json" } as any;
+		mockJsonAssetCreate.mockResolvedValue(mockPackageJsonAsset);
+		mockTextAssetCreate.mockResolvedValue(null);
+
+		plugin.setup(mockApi as unknown as Parameters<ReturnType<typeof FilesArrayPlugin>["setup"]>[0]);
+
+		const callback = mockApi.processAssets.mock.calls[0][1];
+
+		const mockContext = {
+			compilation: {
+				name: "test-env",
+				assets: {
+					"package.json": { source: () => '{"name": "test"}' },
+					"esm/index.js": { source: () => "" },
+					"cjs/index.cjs": { source: () => "" },
+				},
+			},
+		};
+
+		await callback(mockContext);
+
+		const exposedSet = mockApi.expose.mock.calls[0][1] as Set<string>;
+		expect(exposedSet.has("esm")).toBe(true);
+		expect(exposedSet.has("cjs")).toBe(true);
+	});
+
+	it("should filter individual files under formatDirs in optimize-inline stage", async () => {
+		const plugin = FilesArrayPlugin({ target: "npm", formatDirs: ["esm", "cjs"] });
+
+		const mockFilesArray = new Set([
+			"package.json",
+			"tsdoc-metadata.json",
+			"esm",
+			"cjs",
+			"esm/index.js",
+			"esm/index.d.ts",
+			"cjs/index.cjs",
+			"cjs/index.d.cts",
+		]);
+
+		const mockApi = {
+			processAssets: vi.fn(),
+			useExposed: vi.fn().mockReturnValue(mockFilesArray),
+			expose: vi.fn(),
+		};
+
+		const mockPackageJsonAsset = {
+			fileName: "package.json",
+			data: { name: "test", version: "1.0.0", files: [] as string[] },
+			update: vi.fn(),
+			// biome-ignore lint/suspicious/noExplicitAny: Test mocks
+		} as any;
+
+		mockJsonAssetCreate.mockResolvedValue(mockPackageJsonAsset);
+
+		plugin.setup(mockApi as unknown as Parameters<ReturnType<typeof FilesArrayPlugin>["setup"]>[0]);
+
+		const callback = mockApi.processAssets.mock.calls[1][1];
+
+		await callback({
+			compilation: { name: "test-env", assets: {} },
+		});
+
+		expect(mockPackageJsonAsset.data.files).toEqual(["cjs", "esm", "package.json", "tsdoc-metadata.json"]);
+	});
+
 	it("should create files array if not exposed in second processAssets call", async () => {
 		const plugin = FilesArrayPlugin();
 

--- a/src/rslib/plugins/files-array-plugin.ts
+++ b/src/rslib/plugins/files-array-plugin.ts
@@ -54,6 +54,15 @@ export interface FilesArrayPluginOptions<TTarget extends string = string> {
 	 * Passed to the `transformFiles` callback to allow target-specific transformations.
 	 */
 	target: TTarget;
+
+	/**
+	 * Format directories to include in the files array.
+	 * Used in dual format builds so npm's `files` field includes
+	 * format directories (e.g., `["esm", "cjs"]`).
+	 * Directory names are treated as recursive includes by npm,
+	 * so individual files under these dirs are filtered out.
+	 */
+	formatDirs?: string[];
 }
 
 /**
@@ -163,6 +172,14 @@ export const FilesArrayPlugin = <TTarget extends string = string>(
 						}
 					}
 
+					// Add format directories to files array for dual format builds
+					// npm's `files` field treats directory names as recursive includes
+					if (options?.formatDirs) {
+						for (const dir of options.formatDirs) {
+							filesArray.add(dir);
+						}
+					}
+
 					// Call user-provided transformFiles callback if provided
 					if (options?.transformFiles) {
 						await options.transformFiles({
@@ -195,6 +212,16 @@ export const FilesArrayPlugin = <TTarget extends string = string>(
 
 						// Combine existing files with new essential files from filesArray
 						const allFiles = new Set([...previousFiles, ...Array.from(filesArray)].sort());
+
+						// Remove individual files under format directories since the
+						// directory entry already covers them (npm treats dirs as recursive includes)
+						if (options?.formatDirs) {
+							for (const file of [...allFiles]) {
+								if (options.formatDirs.some((dir) => file.startsWith(`${dir}/`))) {
+									allFiles.delete(file);
+								}
+							}
+						}
 
 						if (allFiles.size === 0) {
 							delete packageJson.data.files;


### PR DESCRIPTION
## Summary

- Fix dual format builds (`format: ['esm', 'cjs']`) placing metadata files (package.json, README, LICENSE, api.json, tsdoc-metadata.json, tsconfig.json) inside both `esm/` and `cjs/` subdirectories instead of the shared `dist/{target}/` root
- Use Rsbuild's `distPath.js` to route JS files into format subdirectories while keeping `distPath.root` at the shared root
- Add `dtsPathPrefix` option to DtsPlugin for routing DTS files into format subdirectories
- Add `formatDirs` option to FilesArrayPlugin for clean directory-based `files` array entries
- Strip metadata assets from secondary compilations to prevent overwriting the primary's processed package.json
- Remove 80-char hard line wrapping from all project markdown files caused by a hook misconfiguration

## Test plan

- [x] All 565 unit tests pass
- [x] All 57 E2E tests pass
- [x] Lint clean (biome, markdownlint, tsgo)
- [x] Self-build succeeds with clean output structure
- [ ] Verify CI passes

Signed-off-by: C. Spencer Beggs <spencer@savvyweb.systems>