### PR TITLE
feat(rslib-builder): upgrade rsbuild core to v2 and add usage documentation

### DIFF
--- a/.changeset/calm-island-fe5b54ee.md
+++ b/.changeset/calm-island-fe5b54ee.md
@@ -1,9 +1,0 @@
----
-".": patch
----
-
-## Dependencies
-
-| Dependency | Type | Action | From | To |
-| :--- | :--- | :--- | :--- | :--- |
-| @savvy-web/changesets | devDependency | updated | ^0.7.4 | ^0.8.0 |

--- a/.changeset/clean-things-shave.md
+++ b/.changeset/clean-things-shave.md
@@ -1,0 +1,7 @@
+---
+"@savvy-web/rslib-builder": patch
+---
+
+## Other
+
+Bumps @rsbuild/core to 2.0.0

--- a/.claude/rules/rslib-builder.md
+++ b/.claude/rules/rslib-builder.md
@@ -1,0 +1,137 @@
+---
+paths:
+  - "**/rslib.config.ts"
+---
+
+# @savvy-web/rslib-builder
+
+Standardized build wrapper over RSlib and API Extractor for TypeScript packages. Handles bundled ESM output, rolled-up `.d.ts` declarations, package.json transformation, multi-registry publishing, and API model generation. Packages configure their build entirely through `rslib.config.ts`.
+
+The file must `export default` the result of a builder's `.create()` method:
+
+```typescript
+import { NodeLibraryBuilder } from "@savvy-web/rslib-builder";
+
+export default NodeLibraryBuilder.create();
+```
+
+Entry points are auto-detected from `package.json` `exports` field. Most packages need zero or minimal options.
+
+## NodeLibraryBuilder
+
+For Node.js libraries. Produces bundled ESM (or CJS) with rolled-up types per entry.
+
+```typescript
+NodeLibraryBuilder.create({
+  // -- Format --
+  format?: "esm" | "cjs" | ("esm" | "cjs")[];  // default: "esm"
+  entryFormats?: Record<string, "esm" | "cjs">; // per-entry overrides
+  cjsInterop?: boolean;       // require() returns default directly (default: false)
+
+  // -- Entries --
+  entry?: Record<string, string | string[]>;  // override auto-detected entries
+  exportsAsIndexes?: boolean;  // export paths become dir indexes
+  bundle?: boolean;            // default: true. false = bundleless JS (DTS still bundled)
+  virtualEntries?: Record<string, { source: string; format?: "esm" | "cjs" }>;
+
+  // -- Build --
+  targets?: ("dev" | "npm")[];           // default: ["dev", "npm"]
+  externals?: (string | RegExp)[];       // deps to exclude from bundle
+  dtsBundledPackages?: string[];         // .d.ts packages to inline (minimatch)
+  tsconfigPath?: string;                 // auto-detected if omitted
+  plugins?: RsbuildPlugin[];             // additional Rsbuild plugins
+  define?: Record<string, string>;       // compile-time constants
+  copyPatterns?: (string | CopyPatternConfig)[];  // files to copy to output
+
+  // -- Transforms --
+  transform?: (ctx: { mode, target, pkg }) => PackageJson;  // package.json transform
+  transformFiles?: (ctx: { compilation, filesArray, mode }) => void | Promise<void>;
+
+  // -- API Model (default: enabled) --
+  apiModel?: boolean | ApiModelOptions;  // false to disable
+});
+```
+
+### Realistic example
+
+```typescript
+import { NodeLibraryBuilder } from "@savvy-web/rslib-builder";
+
+export default NodeLibraryBuilder.create({
+  externals: ["@rslib/core", "@rspack/core", "typescript"],
+  copyPatterns: [{ from: "./**/*.json", context: "./src/public" }],
+  apiModel: {
+    tsdoc: {
+      tagDefinitions: [
+        { tagName: "@category", syntaxKind: "modifier" },
+      ],
+    },
+  },
+  transform({ pkg }) {
+    delete pkg.devDependencies;
+    delete pkg.scripts;
+    return pkg;
+  },
+});
+```
+
+## RSPressPluginBuilder
+
+For RSPress plugins. Dual-bundle architecture: plugin entry (always) + runtime React bundle (auto-detected from `src/runtime/index.tsx`).
+
+```typescript
+import { RSPressPluginBuilder } from "@savvy-web/rslib-builder";
+
+export default RSPressPluginBuilder.create({
+  // Plugin bundle (always generated)
+  plugin?: {
+    entry?: string;                   // default: "./src/index.ts"
+    externals?: (string | RegExp)[]; // merged with ["@rspress/core"]
+    plugins?: RsbuildPlugin[];
+    define?: Record<string, string>;
+  };
+
+  // Runtime bundle. Auto-detected if src/runtime/index.tsx exists
+  runtime?: {
+    entry?: string;                   // default: "./src/runtime/index.tsx"
+    externals?: (string | RegExp)[]; // merged with react, @rspress/core, @theme
+    plugins?: RsbuildPlugin[];        // pluginReact() auto-added
+    define?: Record<string, string>;
+  } | false;  // false = explicitly disable
+
+  // Shared options
+  apiModel?: boolean | ApiModelOptions;  // plugin entry only (default: true)
+  dtsBundledPackages?: string[];
+  transform?: (ctx: { mode, target, pkg }) => PackageJson;
+  tsconfigPath?: string;
+  modes?: ("dev" | "npm")[];             // default: ["dev", "npm"]
+  copyPatterns?: (string | CopyPatternConfig)[];
+});
+```
+
+## ApiModelOptions
+
+Both builders enable API model generation by default. Set `apiModel: false` to disable. Generates `<unscopedPackageName>.api.json` in npm mode only.
+
+```typescript
+interface ApiModelOptions {
+  filename?: string;
+  localPaths?: string[];
+  forgottenExports?: "include" | "error" | "ignore";
+  suppressWarnings?: { messageId?: string; pattern?: string }[];
+  tsdocMetadata?: { enabled?: boolean; filename?: string } | boolean;
+  tsdoc?: {
+    groups?: ("core" | "extended" | "discretionary")[];
+    tagDefinitions?: { tagName: string; syntaxKind: "block" | "inline" | "modifier"; allowMultiple?: boolean }[];
+    supportForTags?: Record<string, boolean>;
+    warnings?: "log" | "fail" | "none";
+    lint?: { include?: string[]; onError?: "warn" | "error" | "throw"; persistConfig?: boolean } | boolean;
+  };
+}
+```
+
+## Key Concepts
+
+- **Build modes**: `"dev"` (unminified, source maps) and `"npm"` (optimized). Build via `rslib build --env-mode dev` or `rslib build --env-mode npm`
+- **Publish targets**: Resolved from `publishConfig.targets` in package.json. Each target gets its own output dir with per-target package.json transforms
+- **`transform`**: Mutate package.json before it is written to dist. Called once per publish target, or once with `target: undefined` if no targets

--- a/examples/rspress-plugin/plugin/package.json
+++ b/examples/rspress-plugin/plugin/package.json
@@ -13,7 +13,7 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@rsbuild/plugin-react": "^1.4.0",
+		"@rsbuild/plugin-react": "^2.0.0",
 		"@rspress/core": "^2.0.9",
 		"@savvy-web/rslib-builder": "workspace:*",
 		"@types/node": "catalog:silk",

--- a/package/package.json
+++ b/package/package.json
@@ -52,34 +52,34 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"dependencies": {
-		"@microsoft/api-extractor": "^7.58.2",
+		"@microsoft/api-extractor": "^7.58.7",
 		"@microsoft/tsdoc": "^0.16.0",
 		"@microsoft/tsdoc-config": "^0.18.1",
 		"@pnpm/catalogs.config": "^1100.0.0",
 		"@pnpm/catalogs.protocol-parser": "^1100.0.0",
 		"@pnpm/exportable-manifest": "^1000.4.2",
-		"@pnpm/lockfile.fs": "^1100.0.0",
+		"@pnpm/lockfile.fs": "^1100.0.3",
 		"@pnpm/workspace.read-manifest": "^1000.3.1",
-		"@rsbuild/core": "^1.7.5",
-		"@typescript-eslint/parser": "^8.58.2",
+		"@rsbuild/core": "^2.0.0",
+		"@typescript-eslint/parser": "^8.59.0",
 		"deep-equal": "^2.2.3",
-		"eslint": "^10.2.0",
+		"eslint": "^10.2.1",
 		"eslint-plugin-tsdoc": "^0.5.2",
 		"glob": "^13.0.6",
 		"picocolors": "^1.1.1",
 		"sort-package-json": "^3.6.1",
 		"tmp": "^0.2.4",
-		"workspace-tools": "^0.41.3"
+		"workspace-tools": "^0.41.4"
 	},
 	"devDependencies": {
-		"@pnpm/types": "^1100.0.0",
+		"@pnpm/types": "^1101.0.0",
 		"@rslib/core": "^0.21.1",
 		"@types/deep-equal": "^1.0.4",
 		"@types/tmp": "^0.2.6",
 		"type-fest": "^5.5.0"
 	},
 	"peerDependencies": {
-		"@rsbuild/plugin-react": "^1.4.6",
+		"@rsbuild/plugin-react": "^2.0.0",
 		"@rslib/core": "^0.21.0",
 		"@types/node": "catalog:silkPeers",
 		"@types/react": "catalog:silkPeers",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,8 +144,8 @@ importers:
   examples/rspress-plugin/plugin:
     devDependencies:
       '@rsbuild/plugin-react':
-        specifier: ^1.4.0
-        version: 1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0))
+        specifier: ^2.0.0
+        version: 2.0.0(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0))(@rspack/core@2.0.0(@swc/helpers@0.5.21))
       '@rspress/core':
         specifier: ^2.0.9
         version: 2.0.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
@@ -215,7 +215,7 @@ importers:
   package:
     dependencies:
       '@microsoft/api-extractor':
-        specifier: ^7.58.2
+        specifier: ^7.58.7
         version: 7.58.7(@types/node@25.6.0)
       '@microsoft/tsdoc':
         specifier: ^0.16.0
@@ -233,17 +233,17 @@ importers:
         specifier: ^1000.4.2
         version: 1000.4.2(@pnpm/logger@1001.0.1)
       '@pnpm/lockfile.fs':
-        specifier: ^1100.0.0
+        specifier: ^1100.0.3
         version: 1100.0.3(@pnpm/logger@1001.0.1)
       '@pnpm/workspace.read-manifest':
         specifier: ^1000.3.1
         version: 1000.3.1
       '@rsbuild/core':
-        specifier: ^1.7.5
-        version: 1.7.5
+        specifier: ^2.0.0
+        version: 2.0.0(core-js@3.47.0)
       '@rsbuild/plugin-react':
-        specifier: ^1.4.6
-        version: 1.4.6(@rsbuild/core@1.7.5)
+        specifier: ^2.0.0
+        version: 2.0.0(@rsbuild/core@2.0.0(core-js@3.47.0))(@rspack/core@2.0.0(@swc/helpers@0.5.21))
       '@types/node':
         specifier: catalog:silkPeers
         version: 25.6.0
@@ -254,7 +254,7 @@ importers:
         specifier: catalog:silkPeers
         version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/parser':
-        specifier: ^8.58.2
+        specifier: ^8.59.0
         version: 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
       '@typescript/native-preview':
         specifier: catalog:silkPeers
@@ -263,7 +263,7 @@ importers:
         specifier: ^2.2.3
         version: 2.2.3
       eslint:
-        specifier: ^10.2.0
+        specifier: ^10.2.1
         version: 10.2.1(jiti@2.6.1)
       eslint-plugin-tsdoc:
         specifier: ^0.5.2
@@ -290,12 +290,12 @@ importers:
         specifier: catalog:silkPeers
         version: 6.0.3
       workspace-tools:
-        specifier: ^0.41.3
+        specifier: ^0.41.4
         version: 0.41.4
     devDependencies:
       '@pnpm/types':
-        specifier: ^1100.0.0
-        version: 1100.0.0
+        specifier: ^1101.0.0
+        version: 1101.0.0
       '@rslib/core':
         specifier: ^0.21.1
         version: 0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260422.1)(core-js@3.47.0)(typescript@6.0.3)
@@ -773,24 +773,6 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@module-federation/error-codes@0.22.0':
-    resolution: {integrity: sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==}
-
-  '@module-federation/runtime-core@0.22.0':
-    resolution: {integrity: sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==}
-
-  '@module-federation/runtime-tools@0.22.0':
-    resolution: {integrity: sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==}
-
-  '@module-federation/runtime@0.22.0':
-    resolution: {integrity: sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==}
-
-  '@module-federation/sdk@0.22.0':
-    resolution: {integrity: sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==}
-
-  '@module-federation/webpack-bundler-runtime@0.22.0':
-    resolution: {integrity: sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==}
-
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
     cpu: [arm64]
@@ -820,9 +802,6 @@ packages:
     resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
     cpu: [x64]
     os: [win32]
-
-  '@napi-rs/wasm-runtime@1.0.7':
-    resolution: {integrity: sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==}
 
   '@napi-rs/wasm-runtime@1.1.2':
     resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
@@ -1082,10 +1061,6 @@ packages:
     resolution: {integrity: sha512-NLTXheat/u7OEGg5M5vF6Z85zx8uKUZE0+whtX/sbFV2XL48RdnOWGPTKYuVVkv8M+launaLUTgGEXNs/ess2w==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/types@1100.0.0':
-    resolution: {integrity: sha512-3rxOdRJAcDk66fF7KQQ6uHA3D1kM5oKlUK163UdocyGGPqDJiKyAAbZuIg47l9/6muH5ujKrJstW65sDGQTr0g==}
-    engines: {node: '>=22.13'}
-
   '@pnpm/types@1101.0.0':
     resolution: {integrity: sha512-mDjsSJCsyuWQ6fbh3wa4FL+lx2FtE4GMEP79v6Uqf301Iz40LnD2Jjn2jVnkrPgReftmKV6DxTB/qeWTbtV+oA==}
     engines: {node: '>=22.13'}
@@ -1200,11 +1175,6 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.16':
     resolution: {integrity: sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==}
 
-  '@rsbuild/core@1.7.5':
-    resolution: {integrity: sha512-i37urpoV4y9NSsGiUOuLdoI42KJ5h4gAZ8EG8Ilmsond3bxoAoOCu7YvC+1pJ7p+r16suVPW8cki891ZKHOoXQ==}
-    engines: {node: '>=18.12.0'}
-    hasBin: true
-
   '@rsbuild/core@2.0.0':
     resolution: {integrity: sha512-RbVMK3/4l4g+yt2B/cQv+ardlfGroF1Lgcin3pYUbtsLXKPwDjJII8g0XoCvIgapu0kaA+32YmzKlnfnLGx2NA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1233,6 +1203,14 @@ packages:
       '@rsbuild/core':
         optional: true
 
+  '@rsbuild/plugin-react@2.0.0':
+    resolution: {integrity: sha512-/1gzt39EGUSFEqB83g46QoOwsgv172HI18i6au1b6lgIaX4sv9stuX4ijdHbHCp8PqYEq+MyQ99jIQMO6I+etg==}
+    peerDependencies:
+      '@rsbuild/core': ^2.0.0-0
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+
   '@rslib/core@0.21.3':
     resolution: {integrity: sha512-3kyF273GQWIky4rAGD+Nkewlc7OraRwM2rG6wMJ19cYeomN0OKokVbk0vvfLAcQu43mtEO+dnZk6BchUoRmQOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1246,11 +1224,6 @@ packages:
       typescript:
         optional: true
 
-  '@rspack/binding-darwin-arm64@1.7.11':
-    resolution: {integrity: sha512-oduECiZVqbO5zlVw+q7Vy65sJFth99fWPTyucwvLJJtJkPL5n17Uiql2cYP6Ijn0pkqtf1SXgK8WjiKLG5bIig==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rspack/binding-darwin-arm64@2.0.0':
     resolution: {integrity: sha512-ICBHDKYyndFqljLhjxvKfWWZu39RJSH2jkSmbceXl0kmptLSE0cLWpvk+eGSzLqtxKN0jVchwCw+5P5mWCzwAw==}
     cpu: [arm64]
@@ -1259,11 +1232,6 @@ packages:
   '@rspack/binding-darwin-arm64@2.0.0-rc.1':
     resolution: {integrity: sha512-fYbeDDDg6QKZzXYt/J0/j0Qhr01wQLuISUsYnNhu5MLwdXVUSVcqz+CTqgF3d0EQVVn6FqLV63lbNRzUGfSq9g==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@1.7.11':
-    resolution: {integrity: sha512-a1+TtTE9ap6RalgFi7FGIgkJP6O4Vy6ctv+9WGJy53E4kuqHR0RygzaiVxCI/GMc/vBT9vY23hyrpWb3d1vtXA==}
-    cpu: [x64]
     os: [darwin]
 
   '@rspack/binding-darwin-x64@2.0.0':
@@ -1275,12 +1243,6 @@ packages:
     resolution: {integrity: sha512-MvXi9kr8xXn1y0PD1WI/4YphRNOdbykJjKdEsAG4JxEVoERmhIHOTwKvUqlejajizAwlVZcxQl/FacoPLsKN5Q==}
     cpu: [x64]
     os: [darwin]
-
-  '@rspack/binding-linux-arm64-gnu@1.7.11':
-    resolution: {integrity: sha512-P0QrGRPbTWu6RKWfN0bDtbnEps3rXH0MWIMreZABoUrVmNQKtXR6e73J3ub6a+di5s2+K0M2LJ9Bh2/H4UsDUA==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-arm64-gnu@2.0.0':
     resolution: {integrity: sha512-Ufn33gzkIV7JY69k6vJQEdOzRvBqThIgH46pwXksHSMwRZp8IbJhXfyYIAVsRWCk8fXpr9t1nAvCDvJXT2EeyA==}
@@ -1294,12 +1256,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@1.7.11':
-    resolution: {integrity: sha512-6ky7R43VMjWwmx3Yx7Jl7faLBBMAgMDt+/bN35RgwjiPgsIByz65EwytUVuW9rikB43BGHvA/eqlnjLrUzNBqw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rspack/binding-linux-arm64-musl@2.0.0':
     resolution: {integrity: sha512-CZbvFKlNY9UC0C+Czz6i8JFCzGpuL9oX8gEqcJA1+84Y6eEEBH50UiTzeCewxKW3dOofkZdvT5vgNMXz6aMUmg==}
     cpu: [arm64]
@@ -1311,12 +1267,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     libc: [musl]
-
-  '@rspack/binding-linux-x64-gnu@1.7.11':
-    resolution: {integrity: sha512-cuOJMfCOvb2Wgsry5enXJ3iT1FGUjdPqtGUBVupQlEG4ntSYsQ2PtF4wIDVasR3wdxC5nQbipOrDiN/u6fYsdQ==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-x64-gnu@2.0.0':
     resolution: {integrity: sha512-dPjFGpoCvZfFpJBsWAUR+PR7mWYxpou6L026qIOpAVkz7WiTzErwKD3P1jVrpP4dM9yLb3fVE+PHHjTglhTJ4g==}
@@ -1330,12 +1280,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@1.7.11':
-    resolution: {integrity: sha512-CoK37hva4AmHGh3VCsQXmGr40L36m1/AdnN5LEjUX6kx5rEH7/1nEBN6Ii72pejqDVvk9anEROmPDiPw10tpFg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@rspack/binding-linux-x64-musl@2.0.0':
     resolution: {integrity: sha512-4fgDTMWt0mJDiugdia2mdOjTbnm7yM1Drzl1JpPqlUlOr113byOhc+qgN57LURSGypz2yz/h/Zad7/UnVAxYJw==}
     cpu: [x64]
@@ -1348,10 +1292,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@1.7.11':
-    resolution: {integrity: sha512-OtrmnPUVJMxjNa3eDMfHyPdtlLRmmp/aIm0fQHlAOATbZvlGm12q7rhPW5BXTu1yh+1rQ1/uqvz+SzKEZXuJaQ==}
-    cpu: [wasm32]
-
   '@rspack/binding-wasm32-wasi@2.0.0':
     resolution: {integrity: sha512-ANk73ZKtPrZf9gdtyRK2nQUfhi1uXoC5P2KF89pyVAE8+zcoLBnYtZGYpWa/cmNi5BcO5g4Z+v2l1UA3bUPLQQ==}
     cpu: [wasm32]
@@ -1359,11 +1299,6 @@ packages:
   '@rspack/binding-wasm32-wasi@2.0.0-rc.1':
     resolution: {integrity: sha512-aa9oUTqOb1QjwsHVlMr5sV+7mcBI4MLQ/xhFO2CIEcfVnJIPl8XpKUbDEgqMwcFlzcgzKmHg5cVmIvd82BLgow==}
     cpu: [wasm32]
-
-  '@rspack/binding-win32-arm64-msvc@1.7.11':
-    resolution: {integrity: sha512-lObFW6e5lCWNgTBNwT//yiEDbsxm9QG4BYUojqeXxothuzJ/L6ibXz6+gLMvbOvLGV3nKgkXmx8GvT9WDKR0mA==}
-    cpu: [arm64]
-    os: [win32]
 
   '@rspack/binding-win32-arm64-msvc@2.0.0':
     resolution: {integrity: sha512-IHZFRtJ85ONbM+BCtF4TeYXS2Fu9X0IJS2phX1rPibYq9iEtHGfBt4cNlnsJPhbPAXVvi4Oli/yiLRJ1zxtCIg==}
@@ -1373,11 +1308,6 @@ packages:
   '@rspack/binding-win32-arm64-msvc@2.0.0-rc.1':
     resolution: {integrity: sha512-+UxF0c7E9bE3siFbMHi+mmoeQJzcTKl1j3x+Y6MY/PJ3V70cU23wOaxMvmSsCyq2JNJBT2RCNZ9HaL+o3kReug==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@1.7.11':
-    resolution: {integrity: sha512-0pYGnZd8PPqNR68zQ8skamqNAXEA1sUfXuAdYcknIIRq2wsbiwFzIc0Pov1cIfHYab37G7sSIPBiOUdOWF5Ivw==}
-    cpu: [ia32]
     os: [win32]
 
   '@rspack/binding-win32-ia32-msvc@2.0.0':
@@ -1390,11 +1320,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.7.11':
-    resolution: {integrity: sha512-EeQXayoQk/uBkI3pdoXfQBXNIUrADq56L3s/DFyM2pJeUDrWmhfIw2UFIGkYPTMSCo8F2JcdcGM32FGJrSnU0Q==}
-    cpu: [x64]
-    os: [win32]
-
   '@rspack/binding-win32-x64-msvc@2.0.0':
     resolution: {integrity: sha512-cJOgikIW2t3S+42TQZsv+DJriJt2m6lnUk+pUFu/fO93rrMvNrx8gfMxR8W5zDTreBX0cfMx2pw6EVmyi/YzsQ==}
     cpu: [x64]
@@ -1405,23 +1330,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@1.7.11':
-    resolution: {integrity: sha512-2MGdy2s2HimsDT444Bp5XnALzNRxuBNc7y0JzyuqKbHBywd4x2NeXyhWXXoxufaCFu5PBc9Qq9jyfjW2Aeh06Q==}
-
   '@rspack/binding@2.0.0':
     resolution: {integrity: sha512-WA2f9eQpejkvf5Vrnf6wNCn1m8RT1p08NjgOZpKhsCzr0uBjWeRvGduawlrFFHZh/jPnWZTVaVdQ08FEAWbwGw==}
 
   '@rspack/binding@2.0.0-rc.1':
     resolution: {integrity: sha512-rhJqtbyiRPOjTAZW0xTZFbOrS5yP5yL1SF0DPE9kvFfzePz30IqjMDMxL0KuhkDZd/M1eUINJyoqd8NTbR9wHw==}
-
-  '@rspack/core@1.7.11':
-    resolution: {integrity: sha512-rsD9b+Khmot5DwCMiB3cqTQo53ioPG3M/A7BySu8+0+RS7GCxKm+Z+mtsjtG/vsu4Tn2tcqCdZtA3pgLoJB+ew==}
-    engines: {node: '>=18.12.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
 
   '@rspack/core@2.0.0':
     resolution: {integrity: sha512-WD1mJM9LbZ7Z399Rbv9dE3BNEV0+3sE5OzDdzV8hOxUb3mX++ynK5n9kil8w60B6nGdcKeV9ly5aN4PgqiwWUg==}
@@ -1447,9 +1360,6 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/lite-tapable@1.1.0':
-    resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
-
   '@rspack/plugin-react-refresh@1.6.2':
     resolution: {integrity: sha512-k+/VrfTNgo+KirjI6V+8CWRj6y+DH9jOUWv8JorYY4vKf/9xfnZ8xHzuB4iqCwTtoZl9YnxOaOuoyjJipc2tiQ==}
     peerDependencies:
@@ -1457,6 +1367,15 @@ packages:
       webpack-hot-middleware: 2.x
     peerDependenciesMeta:
       webpack-hot-middleware:
+        optional: true
+
+  '@rspack/plugin-react-refresh@2.0.0':
+    resolution: {integrity: sha512-Cf6CxBStNDJbiXMc/GmsvG1G8PRlUpa0MSfWsMTI+e8npzuTN/p8nwLs3shriBZOLciqgkSZpBtPTd10BLpj1g==}
+    peerDependencies:
+      '@rspack/core': ^2.0.0-0
+      react-refresh: '>=0.10.0 <1.0.0'
+    peerDependenciesMeta:
+      '@rspack/core':
         optional: true
 
   '@rspress/core@2.0.9':
@@ -5551,31 +5470,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@module-federation/error-codes@0.22.0': {}
-
-  '@module-federation/runtime-core@0.22.0':
-    dependencies:
-      '@module-federation/error-codes': 0.22.0
-      '@module-federation/sdk': 0.22.0
-
-  '@module-federation/runtime-tools@0.22.0':
-    dependencies:
-      '@module-federation/runtime': 0.22.0
-      '@module-federation/webpack-bundler-runtime': 0.22.0
-
-  '@module-federation/runtime@0.22.0':
-    dependencies:
-      '@module-federation/error-codes': 0.22.0
-      '@module-federation/runtime-core': 0.22.0
-      '@module-federation/sdk': 0.22.0
-
-  '@module-federation/sdk@0.22.0': {}
-
-  '@module-federation/webpack-bundler-runtime@0.22.0':
-    dependencies:
-      '@module-federation/runtime': 0.22.0
-      '@module-federation/sdk': 0.22.0
-
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
 
@@ -5592,13 +5486,6 @@ snapshots:
     optional: true
 
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.0.7':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -5890,8 +5777,6 @@ snapshots:
 
   '@pnpm/types@1001.3.0': {}
 
-  '@pnpm/types@1100.0.0': {}
-
   '@pnpm/types@1101.0.0': {}
 
   '@pnpm/util.lex-comparator@3.0.2': {}
@@ -5962,14 +5847,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.16': {}
 
-  '@rsbuild/core@1.7.5':
-    dependencies:
-      '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
-      '@rspack/lite-tapable': 1.1.0
-      '@swc/helpers': 0.5.21
-      core-js: 3.47.0
-      jiti: 2.6.1
-
   '@rsbuild/core@2.0.0(core-js@3.47.0)':
     dependencies:
       '@rspack/core': 2.0.0(@swc/helpers@0.5.21)
@@ -5990,15 +5867,6 @@ snapshots:
       - '@emnapi/runtime'
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-react@1.4.6(@rsbuild/core@1.7.5)':
-    dependencies:
-      '@rspack/plugin-react-refresh': 1.6.2(react-refresh@0.18.0)
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rsbuild/core': 1.7.5
-    transitivePeerDependencies:
-      - webpack-hot-middleware
-
   '@rsbuild/plugin-react@1.4.6(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0))':
     dependencies:
       '@rspack/plugin-react-refresh': 1.6.2(react-refresh@0.18.0)
@@ -6007,6 +5875,24 @@ snapshots:
       '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0)
     transitivePeerDependencies:
       - webpack-hot-middleware
+
+  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.0(core-js@3.47.0))(@rspack/core@2.0.0(@swc/helpers@0.5.21))':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.0(@swc/helpers@0.5.21))(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.0.0(core-js@3.47.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0))(@rspack/core@2.0.0(@swc/helpers@0.5.21))':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.0(@swc/helpers@0.5.21))(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(core-js@3.47.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
 
   '@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260422.1)(core-js@3.47.0)(typescript@6.0.3)':
     dependencies:
@@ -6020,16 +5906,10 @@ snapshots:
       - '@typescript/native-preview'
       - core-js
 
-  '@rspack/binding-darwin-arm64@1.7.11':
-    optional: true
-
   '@rspack/binding-darwin-arm64@2.0.0':
     optional: true
 
   '@rspack/binding-darwin-arm64@2.0.0-rc.1':
-    optional: true
-
-  '@rspack/binding-darwin-x64@1.7.11':
     optional: true
 
   '@rspack/binding-darwin-x64@2.0.0':
@@ -6038,16 +5918,10 @@ snapshots:
   '@rspack/binding-darwin-x64@2.0.0-rc.1':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.7.11':
-    optional: true
-
   '@rspack/binding-linux-arm64-gnu@2.0.0':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.0.0-rc.1':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@1.7.11':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.0.0':
@@ -6056,27 +5930,16 @@ snapshots:
   '@rspack/binding-linux-arm64-musl@2.0.0-rc.1':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.7.11':
-    optional: true
-
   '@rspack/binding-linux-x64-gnu@2.0.0':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.0.0-rc.1':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.7.11':
-    optional: true
-
   '@rspack/binding-linux-x64-musl@2.0.0':
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.0.0-rc.1':
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@1.7.11':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.0.0':
@@ -6094,16 +5957,10 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.7.11':
-    optional: true
-
   '@rspack/binding-win32-arm64-msvc@2.0.0':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@2.0.0-rc.1':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@1.7.11':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.0':
@@ -6112,27 +5969,11 @@ snapshots:
   '@rspack/binding-win32-ia32-msvc@2.0.0-rc.1':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.7.11':
-    optional: true
-
   '@rspack/binding-win32-x64-msvc@2.0.0':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.0.0-rc.1':
     optional: true
-
-  '@rspack/binding@1.7.11':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.7.11
-      '@rspack/binding-darwin-x64': 1.7.11
-      '@rspack/binding-linux-arm64-gnu': 1.7.11
-      '@rspack/binding-linux-arm64-musl': 1.7.11
-      '@rspack/binding-linux-x64-gnu': 1.7.11
-      '@rspack/binding-linux-x64-musl': 1.7.11
-      '@rspack/binding-wasm32-wasi': 1.7.11
-      '@rspack/binding-win32-arm64-msvc': 1.7.11
-      '@rspack/binding-win32-ia32-msvc': 1.7.11
-      '@rspack/binding-win32-x64-msvc': 1.7.11
 
   '@rspack/binding@2.0.0':
     optionalDependencies:
@@ -6163,14 +6004,6 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@rspack/core@1.7.11(@swc/helpers@0.5.21)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.22.0
-      '@rspack/binding': 1.7.11
-      '@rspack/lite-tapable': 1.1.0
-    optionalDependencies:
-      '@swc/helpers': 0.5.21
-
   '@rspack/core@2.0.0(@swc/helpers@0.5.21)':
     dependencies:
       '@rspack/binding': 2.0.0
@@ -6186,12 +6019,16 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@rspack/lite-tapable@1.1.0': {}
-
   '@rspack/plugin-react-refresh@1.6.2(react-refresh@0.18.0)':
     dependencies:
       error-stack-parser: 2.1.4
       react-refresh: 0.18.0
+
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.0(@swc/helpers@0.5.21))(react-refresh@0.18.0)':
+    dependencies:
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rspack/core': 2.0.0(@swc/helpers@0.5.21)
 
   '@rspress/core@2.0.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2)':
     dependencies:
@@ -6578,8 +6415,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.56.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.3)
-      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.0
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -7094,7 +6931,8 @@ snapshots:
     dependencies:
       toggle-selection: 1.0.6
 
-  core-js@3.47.0: {}
+  core-js@3.47.0:
+    optional: true
 
   cors@2.8.6:
     dependencies:


### PR DESCRIPTION
# Pull Request

## Summary

Upgrades the core build dependencies `@rsbuild/core` and `@rsbuild/plugin-react` to version `2.0.0`. This major update significantly enhances the build ecosystem and provides updated guidance for projects utilizing `@savvy-web/rslib-builder`.

- **New features/Major upgrades:**
  - Upgrades `@rsbuild/core` to `v2.0.0`, integrating its latest features and improvements into the build pipeline.
  - Upgrades `@rsbuild/plugin-react` to `v2.0.0` for compatibility with the new core.
- **Breaking Changes:**
  - The upgrade to `@rsbuild/core` v2.0.0 introduces breaking changes, primarily affecting how projects configure their builds using `@savvy-web/rslib-builder`. Refer to the new documentation for migration guidance.
- **Other changes:**
  - Adds comprehensive documentation for `@savvy-web/rslib-builder` in `.claude/rules/rslib-builder.md`, detailing `NodeLibraryBuilder` and `RSPressPluginBuilder` configurations aligned with RSBuild v2.
  - Bumps `@microsoft/api-extractor` to `^7.58.7`.
  - Bumps `@pnpm/lockfile.fs` to `^1100.0.3`.
  - Bumps `@typescript-eslint/parser` to `^8.59.0`.
  - Bumps `eslint` to `^10.2.1`.
  - Bumps `workspace-tools` to `^0.41.4`.
  - Bumps `@pnpm/types` devDependency to `^1101.0.0`.
  - Cleans up deprecated or unused packages in `pnpm-lock.yaml`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [X] Breaking change (fix or feature that causes existing functionality
      to change)
- [X] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] All commits are signed off (`git commit -s`) per the [DCO](./DCO)
- [x] Tests pass locally (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Type checking passes (`pnpm typecheck`)
- [x] I have added tests for new functionality (if applicable)
- [X] I have updated documentation (if applicable)

## Related Issues